### PR TITLE
fix(analyzer): locale-aware case fold for Turkish context words

### DIFF
--- a/presidio-analyzer/presidio_analyzer/context_aware_enhancers/lemma_context_aware_enhancer.py
+++ b/presidio-analyzer/presidio_analyzer/context_aware_enhancers/lemma_context_aware_enhancer.py
@@ -86,16 +86,18 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         # create recognizer context dictionary
         recognizers_dict = {recognizer.id: recognizer for recognizer in recognizers}
 
-        # Create empty list in None or lowercase all context words in the list
-        if not context:
-            context = []
-        else:
-            context = [word.lower() for word in context]
-
         # Sanity
         if nlp_artifacts is None:
             logger.warning("NLP artifacts were not provided")
             return results
+
+        # Ensure a context list always exists. Case folding of these words is
+        # deferred to _find_supportive_word_in_context, which folds both sides
+        # of the comparison with the matched recognizer's language (locale-aware
+        # for tr/az). Folding here would lose the original casing needed for
+        # that locale-aware fold.
+        if not context:
+            context = []
 
         for result in results:
             recognizer = None
@@ -138,14 +140,20 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
             word = text[result.start : result.end]
 
             surrounding_words = self._extract_surrounding_words(
-                nlp_artifacts=nlp_artifacts, word=word, start=result.start
+                nlp_artifacts=nlp_artifacts,
+                word=word,
+                start=result.start,
+                language=recognizer.supported_language,
             )
 
             # combine other sources of context with surrounding words
             surrounding_words.extend(context)
 
             supportive_context_word = self._find_supportive_word_in_context(
-                surrounding_words, recognizer.context, self.context_matching_mode
+                surrounding_words,
+                recognizer.context,
+                self.context_matching_mode,
+                recognizer.supported_language,
             )
             if supportive_context_word != "":
                 result.score += self.context_similarity_factor
@@ -161,10 +169,33 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         return results
 
     @staticmethod
+    def _fold(text: str, language: Optional[str] = None) -> str:
+        """Case-fold text using locale-aware rules for the dotted/dotless I.
+
+        Python's ``str.lower`` is locale-independent and mangles Turkish and
+        Azerbaijani casing: ``"İ"`` (U+0130) lowers to ``"i̇"`` (``i`` plus a
+        combining dot) and ``"I"`` (U+0049) lowers to ``"i"`` instead of
+        ``"ı"`` (U+0131). Uppercase context words such as ``"TC KİMLİK NO"``
+        therefore stop containing ``"kimlik"`` after lowering, so the context
+        boost silently fails for the ``tr``/``az`` recognizers.
+
+        For ``tr``/``az`` the dotted/dotless pairs are pre-mapped before
+        lowering. For every other language (and when ``language`` is ``None``)
+        the result is byte-identical to ``text.lower()``.
+
+        :param text: the text to case-fold
+        :param language: the language the surrounding recognizer supports
+        """
+        if language in ("tr", "az"):
+            text = text.replace("İ", "i").replace("I", "ı")
+        return text.lower()
+
+    @staticmethod
     def _find_supportive_word_in_context(
         context_list: List[str],
         recognizer_context_list: List[str],
         matching_mode: str = "substring",
+        language: Optional[str] = None,
     ) -> str:
         """
         Find words in the text which are relevant for context evaluation.
@@ -181,6 +212,8 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
                 context keywords manually specified by the recognizer's author
         :param matching_mode: Matching mode ('whole_word' or 'substring').
                Defaults to 'substring'.
+        :param language: language of the recognizer, used for locale-aware
+               case folding (e.g. the Turkish dotted/dotless I).
         """
         word = ""
         # If the context list is empty, no need to continue
@@ -197,7 +230,10 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
                     (
                         True
                         for keyword in context_list
-                        if predefined_context_word.lower() in keyword.lower()
+                        if LemmaContextAwareEnhancer._fold(
+                            predefined_context_word, language
+                        )
+                        in LemmaContextAwareEnhancer._fold(keyword, language)
                     ),
                     False,
                 )
@@ -207,7 +243,10 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
                     (
                         True
                         for keyword in context_list
-                        if predefined_context_word.lower() == keyword.lower()
+                        if LemmaContextAwareEnhancer._fold(
+                            predefined_context_word, language
+                        )
+                        == LemmaContextAwareEnhancer._fold(keyword, language)
                     ),
                     False,
                 )
@@ -220,7 +259,11 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         return word
 
     def _extract_surrounding_words(
-        self, nlp_artifacts: NlpArtifacts, word: str, start: int
+        self,
+        nlp_artifacts: NlpArtifacts,
+        word: str,
+        start: int,
+        language: Optional[str] = None,
     ) -> List[str]:
         """Extract words surrounding another given word.
 
@@ -232,6 +275,8 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
                               execution on a given text
         :param word: The word to look for context around
         :param start: The start index of the word in the original text
+        :param language: language of the recognizer, used for locale-aware
+                         case folding of the surrounding words
         """
         if not nlp_artifacts.tokens:
             logger.info("Skipping context extraction due to lack of NLP artifacts")
@@ -259,12 +304,14 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
             self.context_prefix_count,
             nlp_artifacts.lemmas,
             lemmatized_keywords,
+            language,
         )
         forward_context = self._add_n_words_forward(
             token_index,
             self.context_suffix_count,
             nlp_artifacts.lemmas,
             lemmatized_keywords,
+            language,
         )
 
         context_list = []
@@ -315,6 +362,7 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         lemmas: List[str],
         lemmatized_filtered_keywords: List[str],
         is_backward: bool,
+        language: Optional[str] = None,
     ) -> List[str]:
         """
         Prepare a string of context words.
@@ -329,6 +377,8 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
                lemmas from the original sentence,
         :param is_backward: if true take the preceeding words, if false,
                             take the successing words
+        :param language: language of the recognizer, used for locale-aware
+               case folding of the collected words
         """
         i = index
         context_words = []
@@ -340,9 +390,16 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         # collect at most n words (in lower case)
         remaining = n_words + 1
         while 0 <= i < len(lemmas) and remaining > 0:
+            # Membership is tested against the plain-lowercased keywords built
+            # by NlpArtifacts, but the collected word is case-folded so that
+            # locale-sensitive lemmas (e.g. Turkish "KAYIT") match the
+            # recognizer context words. For non-tr/az languages _fold is
+            # identical to str.lower, so this is byte-for-byte unchanged.
             lower_lemma = lemmas[i].lower()
             if lower_lemma in lemmatized_filtered_keywords:
-                context_words.append(lower_lemma)
+                context_words.append(
+                    LemmaContextAwareEnhancer._fold(lemmas[i], language)
+                )
                 remaining -= 1
             i = i - 1 if is_backward else i + 1
         return context_words
@@ -353,9 +410,10 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         n_words: int,
         lemmas: List[str],
         lemmatized_filtered_keywords: List[str],
+        language: Optional[str] = None,
     ) -> List[str]:
         return self._add_n_words(
-            index, n_words, lemmas, lemmatized_filtered_keywords, False
+            index, n_words, lemmas, lemmatized_filtered_keywords, False, language
         )
 
     def _add_n_words_backward(
@@ -364,7 +422,8 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
         n_words: int,
         lemmas: List[str],
         lemmatized_filtered_keywords: List[str],
+        language: Optional[str] = None,
     ) -> List[str]:
         return self._add_n_words(
-            index, n_words, lemmas, lemmatized_filtered_keywords, True
+            index, n_words, lemmas, lemmatized_filtered_keywords, True, language
         )

--- a/presidio-analyzer/tests/test_lemma_context_aware_enhancer.py
+++ b/presidio-analyzer/tests/test_lemma_context_aware_enhancer.py
@@ -81,6 +81,45 @@ def test_when_context_word_case_insensitive_then_succeed():
     assert result == "LIC"
 
 
+def test_when_whole_word_turkish_context_then_locale_aware_match():
+    """
+    Test that whole_word matching folds the Turkish dotted/dotless I.
+
+    An uppercase Turkish surrounding word ("KAYIT") should match its lowercase
+    recognizer keyword ("kayıt") when the recognizer language is 'tr'/'az',
+    because 'I' (U+0049) must fold to 'ı' (U+0131) rather than 'i'. Without the
+    language, plain str.lower() yields "kayit" and the whole-word match fails.
+    """
+    context_list = ["KAYIT"]
+    recognizer_context_list = ["kayıt"]
+
+    # With the Turkish language the dotless-I fold makes the words equal.
+    result = LemmaContextAwareEnhancer._find_supportive_word_in_context(
+        context_list,
+        recognizer_context_list,
+        matching_mode="whole_word",
+        language="tr",
+    )
+    assert result == "kayıt"
+
+    # Azerbaijani shares the same dotted/dotless I casing rules.
+    result = LemmaContextAwareEnhancer._find_supportive_word_in_context(
+        context_list,
+        recognizer_context_list,
+        matching_mode="whole_word",
+        language="az",
+    )
+    assert result == "kayıt"
+
+    # Without a locale, str.lower() maps "KAYIT" -> "kayit" and the match fails.
+    result = LemmaContextAwareEnhancer._find_supportive_word_in_context(
+        context_list,
+        recognizer_context_list,
+        matching_mode="whole_word",
+    )
+    assert result == ""
+
+
 def test_when_context_word_multiple_matches_then_first_match_returned():
     """
     Test that when multiple context words match, the first one is returned.

--- a/presidio-analyzer/tests/test_tr_license_plate_recognizer.py
+++ b/presidio-analyzer/tests/test_tr_license_plate_recognizer.py
@@ -1,6 +1,12 @@
 """Tests for Turkish license plate (TR_LICENSE_PLATE) recognizer."""
 
 import pytest
+from presidio_analyzer import (
+    AnalysisExplanation,
+    LemmaContextAwareEnhancer,
+    RecognizerResult,
+)
+from presidio_analyzer.nlp_engine import NlpArtifacts, NoOpNlpEngine
 from presidio_analyzer.predefined_recognizers import TrLicensePlateRecognizer
 
 from tests import assert_result_within_score_range
@@ -122,3 +128,53 @@ def test_supported_entity(recognizer):
 def test_supported_language(recognizer):
     """Test that supported language is correctly set."""
     assert recognizer.supported_language == "tr"
+
+
+def test_uppercase_turkish_context_boosts_score(recognizer):
+    """An uppercase Turkish word near the plate must boost the score.
+
+    Turkish vehicle documents are written in uppercase, e.g. "KAYIT".
+    ``str.lower`` lowers the dotless-capital "I" (U+0049) to "i" instead of "ı"
+    (U+0131), so "KAYIT" becomes "kayit" and no longer matches the recognizer's
+    "kayıt" context word. The context enhancer must case-fold with Turkish
+    rules; before the fix this assertion fails because the surrounding word
+    never matches and the score stays at the pattern baseline.
+
+    The NlpArtifacts are built directly with a fixed lemma sequence so the
+    lemma-extraction path is exercised deterministically without depending on a
+    Turkish spaCy model.
+    """
+    text = "KAYIT 34ABC1234"
+    baseline_score = 0.3
+
+    nlp_engine = NoOpNlpEngine(models=[{"lang_code": "tr", "model_name": "no_op"}])
+    nlp_engine.load()
+    nlp_artifacts = NlpArtifacts(
+        entities=[],
+        tokens=["KAYIT", "34ABC1234"],
+        tokens_indices=[0, 6],
+        lemmas=["KAYIT", "34ABC1234"],
+        nlp_engine=nlp_engine,
+        language="tr",
+    )
+
+    result = RecognizerResult(
+        entity_type="TR_LICENSE_PLATE",
+        start=6,
+        end=15,
+        score=baseline_score,
+        analysis_explanation=AnalysisExplanation(
+            recognizer=recognizer.name, original_score=baseline_score
+        ),
+        recognition_metadata={
+            RecognizerResult.RECOGNIZER_NAME_KEY: recognizer.name,
+            RecognizerResult.RECOGNIZER_IDENTIFIER_KEY: recognizer.id,
+        },
+    )
+
+    enhanced = LemmaContextAwareEnhancer().enhance_using_context(
+        text, [result], nlp_artifacts, [recognizer]
+    )
+
+    assert enhanced[0].score > baseline_score
+    assert enhanced[0].analysis_explanation.supportive_context_word == "kayıt"

--- a/presidio-analyzer/tests/test_tr_national_id_recognizer.py
+++ b/presidio-analyzer/tests/test_tr_national_id_recognizer.py
@@ -1,6 +1,12 @@
 """Tests for Turkish National ID (TCKN) recognizer."""
 
 import pytest
+from presidio_analyzer import (
+    AnalysisExplanation,
+    LemmaContextAwareEnhancer,
+    RecognizerResult,
+)
+from presidio_analyzer.nlp_engine import NoOpNlpEngine
 from presidio_analyzer.predefined_recognizers import TrNationalIdRecognizer
 
 from tests import assert_result_within_score_range
@@ -169,3 +175,44 @@ def test_supported_entity(recognizer):
 def test_supported_language(recognizer):
     """Test that supported language is correctly set."""
     assert recognizer.supported_language == "tr"
+
+
+def test_uppercase_turkish_context_boosts_score(recognizer):
+    """Uppercase Turkish context words must boost the recognizer's score.
+
+    Turkish identity documents are written in uppercase, e.g. "TC KİMLİK NO".
+    ``str.lower`` is locale-independent and lowers "İ" (U+0130) to "i" plus a
+    combining dot, so "kimlik" is no longer a substring of the lowered text and
+    the recognizer's shipped context list never matches. The context enhancer
+    must case-fold with Turkish rules; before the fix this assertion fails
+    because the score stays at the pattern baseline.
+    """
+    text = "TC KİMLİK NO: 10000000146"
+    baseline_score = 0.3
+
+    # No-op artifacts carry no lemmas, so any boost must come from matching the
+    # explicitly supplied context against the recognizer's own context list.
+    nlp_engine = NoOpNlpEngine(models=[{"lang_code": "tr", "model_name": "no_op"}])
+    nlp_engine.load()
+    nlp_artifacts = nlp_engine.process_text(text, "tr")
+
+    result = RecognizerResult(
+        entity_type="TR_NATIONAL_ID",
+        start=14,
+        end=25,
+        score=baseline_score,
+        analysis_explanation=AnalysisExplanation(
+            recognizer=recognizer.name, original_score=baseline_score
+        ),
+        recognition_metadata={
+            RecognizerResult.RECOGNIZER_NAME_KEY: recognizer.name,
+            RecognizerResult.RECOGNIZER_IDENTIFIER_KEY: recognizer.id,
+        },
+    )
+
+    enhanced = LemmaContextAwareEnhancer().enhance_using_context(
+        text, [result], nlp_artifacts, [recognizer], context=["TC KİMLİK NO"]
+    )
+
+    assert enhanced[0].score > baseline_score
+    assert enhanced[0].analysis_explanation.supportive_context_word == "tc kimlik"


### PR DESCRIPTION
## Change Description

`LemmaContextAwareEnhancer` lowercases context words and surrounding lemmas with
`str.lower()` before comparing them. `str.lower()` is locale-independent, and for
Turkish/Azerbaijani it produces the wrong result for the dotted/dotless *I*:

```python
>>> "TC KİMLİK NO".lower()
'tc ki̇mli̇k no'      # "İ" (U+0130) -> "i" + U+0307 combining dot
>>> "kimlik" in "TC KİMLİK NO".lower()
False
>>> "NÜFUS CÜZDANI".lower()
'nüfus cüzdani'       # "I" (U+0049) -> "i" instead of "ı" (U+0131)
```

Because of this, a context word written in uppercase (which is how Turkish ID and
vehicle documents are usually printed) no longer contains the recognizer's context
term, so the context confidence boost is never applied for that input.

This is visible with the bundled Turkish recognizers, whose context lists are
lowercase Turkish (`"tc kimlik"`, `"kimlik no"`, `"kayıt"`, …): those words never
match their own uppercase form. (These recognizers are country-specific and ship
`enabled: false` in `default_recognizers.yaml`, so this only affects users who opt
into them — the point is that once enabled, their context matching is locale-broken
for uppercase input.)

### Fix

Add a small `_fold(text, language)` helper on the enhancer. When the recognizer's
`supported_language` is `tr`/`az`, the dotted/dotless *I* pairs are pre-mapped
(`İ→i`, `I→ı`) before lowering; for every other language (and when no language is
given) `_fold` returns exactly `text.lower()`. The language is taken from the
matched recognizer.

**Which sites fold, which stay plain.** The old up-front
`context = [word.lower() for word in context]` at the top of `enhance_using_context`
is **removed** — folding the caller-supplied `context` early would discard the
original casing that the locale-aware fold needs, so those words are now folded at
comparison time instead. The two comparison sites in
`_find_supportive_word_in_context` (the `substring` branch and the `whole_word`
branch) fold **both** operands through `_fold`, and the *stored* surrounding word
appended in `_add_n_words` is folded as well. One `.lower()` deliberately stays
plain: the membership test `lemmas[i].lower() in lemmatized_filtered_keywords` in
`_add_n_words`, because those keywords are the plain-`str.lower()` keywords built by
`NlpArtifacts` and must be compared like-for-like — folding only the collected word
that is later compared against the recognizer context.

**Zero blast radius for non-tr/az:** for any other language `_fold(x, lang)` is
byte-for-byte identical to `x.lower()`, so existing behaviour is unchanged.

### Why this lives in the core enhancer (and why `casefold()` is not enough)

The fold is applied once, in `LemmaContextAwareEnhancer`, rather than in each
Turkish recognizer. The lowering that breaks the match happens **inside** the
enhancer — recognizers only declare their lowercase context lists and never see the
surrounding-word lowering, so a recognizer has no seam at which to intervene.
Putting the rule in each recognizer would duplicate it across every current and
future `tr`/`az` recognizer and still could not touch the enhancer's own
`str.lower()` on surrounding lemmas. Keying off the recognizer's already-declared
`supported_language` keeps the rule in exactly one place and leaves every other
language on the identical code path.

Switching the existing calls to `str.casefold()` does **not** fix this. `casefold()`
is also locale-independent: `"TC KİMLİK NO".casefold()` still yields
`'tc ki̇mli̇k no'` (with the combining dot) and `"KAYIT".casefold()` still yields
`'kayit'`, not `'kayıt'`. The dotted/dotless *I* has to be mapped explicitly for
`tr`/`az`, which is what `_fold` does before lowering.

### Tests

Failing-then-fix unit tests were added for both bundled Turkish recognizers,
asserting that uppercase Turkish context raises the score above the pattern
baseline and records the matching context word:

- `test_tr_national_id_recognizer.py`: `"TC KİMLİK NO"` supplied as context.
- `test_tr_license_plate_recognizer.py`: `"KAYIT"` as a surrounding lemma
  (exercising the lemma-extraction path).

Both assertions fail on `main` (score stays at the baseline) and pass with the fix.

A unit test for the `whole_word` branch was also added to
`test_lemma_context_aware_enhancer.py`
(`test_when_whole_word_turkish_context_then_locale_aware_match`) so the Turkish
path of the `whole_word` fold site is asserted directly:
`"KAYIT"` matches `"kayıt"` with `language="tr"`/`"az"`, and does **not** match
without a locale. The remaining existing
`test_lemma_context_aware_enhancer.py` and `test_context_support.py` cases
continue to pass unchanged.

## Issue reference

No pre-existing issue on the tracker; the defect and a runnable reproduction are
described in the Change Description above.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
