### PR TITLE
feat(analyzer): add Korean bank account number recognizer (KR_BANK_ACCOUNT)

### DIFF
--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -113,6 +113,7 @@ For more information, refer to the [adding new recognizers documentation](analyz
 | KR_PASSPORT| The Korean Passport Number  | Pattern match, context. |
 | KR_BRN     | The Korean Business Registration Number (BRN) is a 10-digit number assigned to business entities for taxation purposes. | Pattern match, context and custom logic. |
 | KR_RRN     | The Korean Resident Registration Number (RRN) is a 13-digit number issued to all Korean residents. | Pattern match, context and custom logic. |
+| KR_BANK_ACCOUNT | The Korean bank account number: 10-14 digit bank-specific formats with no unified checksum. | Pattern match, context. |
 
 
 ### Nigeria

--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -303,7 +303,6 @@ recognizers:
   - name: KrBankAccountRecognizer
     supported_languages:
     - ko
-    - kr
     type: predefined
     enabled: false
     country_code: kr

--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -300,6 +300,14 @@ recognizers:
     enabled: false
     country_code: fi
 
+  - name: KrBankAccountRecognizer
+    supported_languages:
+    - ko
+    - kr
+    type: predefined
+    enabled: false
+    country_code: kr
+
   - name: KrBrnRecognizer
     supported_languages: 
     - ko

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -62,6 +62,9 @@ from .country_specific.italy.it_passport_recognizer import ItPassportRecognizer
 from .country_specific.italy.it_vat_code import ItVatCodeRecognizer
 
 # Korea recognizers
+from .country_specific.korea.kr_bank_account_recognizer import (
+    KrBankAccountRecognizer,
+)
 from .country_specific.korea.kr_brn_recognizer import KrBrnRecognizer
 from .country_specific.korea.kr_driver_license_recognizer import (
     KrDriverLicenseRecognizer,
@@ -271,6 +274,7 @@ __all__ = [
     "UkPostcodeRecognizer",
     "UkVehicleRegistrationRecognizer",
     "AzureHealthDeidRecognizer",
+    "KrBankAccountRecognizer",
     "KrBrnRecognizer",
     "KrRrnRecognizer",
     "KrDriverLicenseRecognizer",

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/__init__.py
@@ -1,5 +1,6 @@
 """Korea-specific recognizers."""
 
+from .kr_bank_account_recognizer import KrBankAccountRecognizer
 from .kr_brn_recognizer import KrBrnRecognizer
 from .kr_driver_license_recognizer import KrDriverLicenseRecognizer
 from .kr_frn_recognizer import KrFrnRecognizer
@@ -7,11 +8,10 @@ from .kr_passport_recognizer import KrPassportRecognizer
 from .kr_rrn_recognizer import KrRrnRecognizer
 
 __all__ = [
-    "KrDriverLicenseRecognizer",
-    "KrPassportRecognizer",
-    "KrFrnRecognizer",
+    "KrBankAccountRecognizer",
     "KrBrnRecognizer",
     "KrDriverLicenseRecognizer",
+    "KrFrnRecognizer",
     "KrPassportRecognizer",
     "KrRrnRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/kr_bank_account_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/kr_bank_account_recognizer.py
@@ -1,0 +1,86 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class KrBankAccountRecognizer(PatternRecognizer):
+    """
+    Recognize Korean bank account numbers.
+
+    Korean bank account numbers are 10-14 digit identifiers issued in
+    bank-specific segment layouts, commonly written with hyphens
+    (e.g. NongHyup's 302-XXXX-XXXX-XX personal accounts, or common
+    three-segment forms such as 110-234-567890). No unified national
+    format or check digit exists, so precision comes from structural
+    patterns plus negative lookaheads that exclude look-alike shapes:
+    Korean mobile/VoIP phone numbers (010/011/016/017/019/070),
+    resident registration numbers and calendar dates.
+
+    Reference: per-bank layouts (e.g. NongHyup's 3YY-XXXX-XXXX-CC
+    personal accounts) are documented at
+    https://namu.wiki/w/%EA%B3%84%EC%A2%8C%EB%B2%88%ED%98%B8
+    Patterns were validated in a production Korean PII-masking deployment.
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    COUNTRY_CODE = "kr"
+
+    PATTERNS = [
+        Pattern(
+            "NH 4-segment account (Medium)",
+            r"(?<!\d)302-\d{3,4}-\d{3,4}-\d{2}(?!\d)",
+            0.6,
+        ),
+        Pattern(
+            "Hyphenated 3-segment account (Weak)",
+            r"(?<!\d)(?!(?:01[01679]|070)-\d{3,4}-\d{4}(?!\d))"
+            r"(?!\d{4}[-./]\d{1,2}[-./]\d{1,2}(?!\d))(?=(?:\d-?){9,16}(?!\d))"
+            r"\d{2,3}-\d{2,6}-\d{1,7}(?!\d)",
+            0.3,
+        ),
+        Pattern(
+            "Mixed-separator account (Very weak)",
+            r"(?<!\d)(?!\d{6}-?\d{7}(?!\d))"
+            r"(?!(?:01[01679]|070)[- ]?\d{3,4}[- ]?\d{4}(?!\d))"
+            r"(?!\d{4}[-./]\d{1,2}[-./]\d{1,2}(?!\d))(?=(?:\d[- ]?){9,16}(?!\d))"
+            r"\d{2,4}(?:[- ]?\d{2,6})(?:[- ]?\d{1,7})(?:[- ]?\d{1,3})?(?!\d)",
+            0.15,
+        ),
+    ]
+
+    CONTEXT = [
+        "계좌",
+        "계좌번호",
+        "예금주",
+        "송금",
+        "입금",
+        "입금계좌",
+        "출금",
+        "이체",
+        "타행",
+        "은행",
+        "bank account",
+        "account number",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "ko",
+        supported_entity: str = "KR_BANK_ACCOUNT",
+        name: Optional[str] = None,
+    ):
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )

--- a/presidio-analyzer/tests/test_kr_bank_account_recognizer.py
+++ b/presidio-analyzer/tests/test_kr_bank_account_recognizer.py
@@ -1,9 +1,17 @@
-import pytest
+from pathlib import Path
 
-from tests import assert_result_within_score_range
+import presidio_analyzer
+import pytest
+import yaml
+from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.context_aware_enhancers import LemmaContextAwareEnhancer
+from presidio_analyzer.nlp_engine import NoOpNlpEngine
 from presidio_analyzer.predefined_recognizers.country_specific.korea import (
     KrBankAccountRecognizer,
 )
+from presidio_analyzer.recognizer_registry import RecognizerRegistryProvider
+
+from tests import assert_result_within_score_range
 
 
 @pytest.fixture(scope="module")
@@ -63,3 +71,111 @@ def test_when_account_like_then_best_match_found(
 )
 def test_when_look_alike_then_no_match(text, recognizer, entities):
     assert recognizer.analyze(text, entities) == []
+
+
+NOOP_KO = {"lang_code": "ko", "model_name": "no_op"}
+
+
+def shipped_yaml_entry():
+    conf = Path(presidio_analyzer.__file__).parent / "conf" / "default_recognizers.yaml"
+    recognizers = yaml.safe_load(conf.read_text(encoding="utf-8"))["recognizers"]
+    entries = [r for r in recognizers if r.get("name") == "KrBankAccountRecognizer"]
+    assert len(entries) == 1, "KrBankAccountRecognizer missing from YAML"
+    return entries[0]
+
+
+def test_when_enabled_in_yaml_then_loads_and_detects_through_analyzer():
+    """Detection must work through the path users actually configure.
+
+    The shipped entry is enabled, loaded by ``RecognizerRegistryProvider`` and
+    exercised through ``AnalyzerEngine`` so the language routing runs too. The
+    generic loader test already proves the entry instantiates; this pins that
+    the instance built from configuration detects with the same score as one
+    built directly. ``NoOpNlpEngine`` stands in for a Korean NLP model.
+
+    Note that ``ko`` has to be declared in three places for this to work: the
+    registry's top-level ``supported_languages``, the NLP engine's models and
+    the analyzer engine's ``supported_languages``. Missing any of them fails
+    quietly or with an unrelated-looking error.
+    """
+    entry = shipped_yaml_entry()
+    assert entry["supported_languages"] == ["ko"]
+    assert entry["country_code"] == "kr"
+
+    registry = RecognizerRegistryProvider(
+        registry_configuration={
+            "supported_languages": ["ko"],
+            "recognizers": [dict(entry, enabled=True)],
+        }
+    ).create_recognizer_registry()
+    analyzer = AnalyzerEngine(
+        registry=registry,
+        nlp_engine=NoOpNlpEngine(models=[NOOP_KO]),
+        supported_languages=["ko"],
+    )
+
+    results = analyzer.analyze("이체 계좌: 302-0123-4567-89", language="ko")
+
+    assert [r.entity_type for r in results] == ["KR_BANK_ACCOUNT"]
+    assert_result_within_score_range(results[0], "KR_BANK_ACCOUNT", 7, 23, 0.6, 0.6)
+
+
+def test_when_top_level_languages_left_at_default_then_entry_loads_nothing():
+    """The shipped top-level ``supported_languages`` is ``["en"]``.
+
+    Flipping only ``enabled: true`` therefore loads nothing, with no error,
+    which is why enabling this entry also requires adding ``ko`` at the top.
+    """
+    registry = RecognizerRegistryProvider(
+        registry_configuration={
+            "supported_languages": ["en"],
+            "recognizers": [dict(shipped_yaml_entry(), enabled=True)],
+        }
+    ).create_recognizer_registry()
+
+    assert registry.recognizers == []
+
+
+def test_when_korean_context_word_is_supplied_then_score_is_boosted(
+    recognizer, entities
+):
+    """The Korean context words must be wired into the context enhancer.
+
+    Context taken from the surrounding text needs a Korean NLP model, which
+    the test environment does not ship, so the boost is exercised through the
+    explicit ``context`` argument, the same way ``test_context_support`` does.
+    """
+    text = "302-1234-5678-91"
+    engine = NoOpNlpEngine(models=[NOOP_KO])
+    engine.load()
+    nlp_artifacts = engine.process_text(text, "ko")
+    raw = recognizer.analyze(text, entities, nlp_artifacts)
+    enhancer = LemmaContextAwareEnhancer()
+
+    without = enhancer.enhance_using_context(text, raw, nlp_artifacts, [recognizer])
+    boosted = enhancer.enhance_using_context(
+        text, raw, nlp_artifacts, [recognizer], ["계좌번호"]
+    )
+
+    assert max(r.score for r in without) == 0.6
+    best = max(boosted, key=lambda r: r.score)
+    assert best.score == pytest.approx(0.95)
+    assert best.analysis_explanation.supportive_context_word in recognizer.context
+
+
+@pytest.mark.parametrize(
+    "text, start, end",
+    [
+        # context word before the account: the default prefix window
+        ("계좌번호 302-1234-5678-91 로 입금", 5, 21),
+        # context word after the account: the suffix window, off by default
+        ("302-1234-5678-91 계좌로 이체 부탁드립니다", 0, 16),
+    ],
+)
+def test_when_context_word_on_either_side_then_pattern_match_is_kept(
+    text, start, end, recognizer, entities
+):
+    """Context text on either side must not disturb the pattern match itself."""
+    results = recognizer.analyze(text, entities)
+    best = max(results, key=lambda r: r.score)
+    assert_result_within_score_range(best, entities[0], start, end, 0.6, 0.6)

--- a/presidio-analyzer/tests/test_kr_bank_account_recognizer.py
+++ b/presidio-analyzer/tests/test_kr_bank_account_recognizer.py
@@ -1,0 +1,65 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers.country_specific.korea import (
+    KrBankAccountRecognizer,
+)
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return KrBankAccountRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["KR_BANK_ACCOUNT"]
+
+
+# Patterns overlap by design (an NH account also matches the generic layouts),
+# so positive cases assert on the best-scoring match instead of result counts.
+@pytest.mark.parametrize(
+    "text, start, end, score",
+    [
+        # NH (NongHyup) 302-prefixed 4-segment personal account
+        ("302-1234-5678-91", 0, 16, 0.6),
+        ("이체 계좌: 302-0123-4567-89", 7, 23, 0.6),
+        # Common hyphenated 3-segment layouts
+        ("110-234-567890", 0, 14, 0.3),
+        ("457-910-012345", 0, 14, 0.3),
+        # Mixed/plain digit runs (9-16 digits, excluding the 13-digit RRN shape)
+        ("987654321012", 0, 12, 0.15),
+        ("1002-123-456789", 0, 15, 0.15),
+    ],
+)
+def test_when_account_like_then_best_match_found(
+    text, start, end, score, recognizer, entities
+):
+    results = recognizer.analyze(text, entities)
+    assert results
+    best = max(results, key=lambda r: r.score)
+    assert_result_within_score_range(best, entities[0], start, end, score, score)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Korean mobile / VoIP phone numbers must not match
+        "010-1234-5678",
+        "070-1234-5678",
+        "01012345678",
+        "07012345678",
+        # Resident registration number shapes must not match
+        "960121-1234567",
+        "9601211234567",
+        # Any 13-digit pure run is left to KR_RRN's domain
+        "9876543210123",
+        # Dates must not match
+        "2024-03-10",
+        # Too short
+        "45000",
+        "12345678",
+    ],
+)
+def test_when_look_alike_then_no_match(text, recognizer, entities):
+    assert recognizer.analyze(text, entities) == []


### PR DESCRIPTION
## Change Description

Add `KrBankAccountRecognizer` (entity `KR_BANK_ACCOUNT`) under `country_specific/korea/`, registered in the predefined recognizer exports, `default_recognizers.yaml` (disabled by default, `country_code: kr`) and the supported entities docs.

Korean bank account numbers had no coverage. The patterns are ported from a production Korean PII-masking deployment, with conservative scores (no checksum exists for Korean accounts) and negative lookaheads for phone (010/070), RRN and date look-alikes. Plain 13-digit runs are deliberately left to KR_RRN's domain.

Tests: positive cases assert the best-scoring match per layout (the patterns overlap by design), and a look-alike table asserts zero matches for Korean phone numbers, RRN shapes, dates and short digit runs. The full analyzer suite (3047 tests) and `ruff check` pass.

## Issue reference

Fixes #2214

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required


## Update: aligned with the recognizer instructions from #2211

- Configuration-path test: the shipped entry is enabled, loaded through `RecognizerRegistryProvider` and exercised through `AnalyzerEngine` with a no-op Korean engine, asserting detection with the same score as direct construction. A negative case pins the instructions' warning: leaving the top-level `supported_languages` at the shipped `["en"]` loads nothing, with no error. Enabling this entry therefore needs `ko` in the top-level languages (and in the NLP and analyzer engine languages).
- Context coverage: the Korean context words are shown to raise the score through the enhancer's explicit `context` argument (0.6 to 0.95), the same route `test_context_support` uses, since text-derived context needs a Korean NLP model the test environment does not ship. Context text on either side of the match is also covered at the pattern level.
- The YAML entry lists `ko` only (ISO 639-1), in its own commit. The neighbouring `Kr*` entries still carry `kr`, which #2236 traces back to a deliberate backward-compatibility alias from #1742 for recognizers whose class default used to be `kr`; this recognizer has only ever defaulted to `ko`, so there is no configuration that could depend on `kr` here. #2236 handles the existing entries.

