### PR TITLE
fix: snap chunk start to a word boundary in CharacterBasedTextChunker

### DIFF
--- a/presidio-analyzer/presidio_analyzer/chunkers/character_based_text_chunker.py
+++ b/presidio-analyzer/presidio_analyzer/chunkers/character_based_text_chunker.py
@@ -119,5 +119,8 @@ class CharacterBasedTextChunker(BaseTextChunker):
                 break
             start = end - self._chunk_overlap
 
+            while start < end and text[start] not in self._boundary_chars:
+                start += 1
+
         logger.debug("Created %d chunks from text", len(chunks))
         return chunks

--- a/presidio-analyzer/tests/test_character_based_text_chunker.py
+++ b/presidio-analyzer/tests/test_character_based_text_chunker.py
@@ -76,6 +76,25 @@ class TestCharacterBasedTextChunkerChunk:
         for chunk in chunks:
             assert text[chunk.start:chunk.end] == chunk.text
 
+    def test_chunk_start_lands_on_word_boundary(self):
+        """Test that every chunk after the first begins on a word boundary."""
+        chunker = CharacterBasedTextChunker(chunk_size=10, chunk_overlap=3)
+        text = "This is a test string for chunking purposes"
+        chunks = chunker.chunk(text)
+
+        assert len(chunks) > 1, "test needs multiple chunks to exercise the bug"
+        for chunk in chunks[1:]:
+            # "mid-word" means both neighbours of `start` are non-boundary chars
+            # (start sits strictly between two letters of the same word). A
+            # start landing ON a boundary char, or right after one, is fine.
+            before_is_boundary = (
+                chunk.start == 0 or text[chunk.start - 1] in chunker.boundary_chars
+            )
+            at_is_boundary = text[chunk.start] in chunker.boundary_chars
+            assert before_is_boundary or at_is_boundary, (
+                f"chunk starting at {chunk.start} begins mid-word: {chunk.text[:20]!r}"
+            )
+
 
 class TestCharacterBasedTextChunkerEdgeCases:
     """Edge case tests for CharacterBasedTextChunker."""


### PR DESCRIPTION
## Change Description

`CharacterBasedTextChunker` snaps `end` forward to the next boundary char so a chunk never *ends* mid-word. But `start`, computed as `end - chunk_overlap`, gets no equivalent treatment — the subtraction discards the alignment established two lines earlier.

With `chunk_size=10, chunk_overlap=3`:

text = "This is a test string for chunking purposes"

before: ['This is a test', 'st string for', 'or chunking', 'ing purposes']
after:  ['This is a test', ' string for', ' chunking purposes']

Three of the four chunks begin mid-word. An NER recognizer receives `'st'`, `'or'`, `'ing'` as standalone tokens and can confidently mislabel them as entities, producing a false positive that redacts the wrong span.

**Fix:** advance `start` to the next boundary char, mirroring the loop `end` already has. Three lines.

Present since #1805, which introduced this chunker.

## Issue reference

No existing issue. Found while using the chunker via `GLiNERRecognizer` on long transcripts.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
