### PR TITLE
fix(analyzer): make the shipped HuggingFaceNerRecognizer entry loadable

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/huggingface_ner_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/huggingface_ner_recognizer.py
@@ -257,17 +257,13 @@ class HuggingFaceNerRecognizer(LocalRecognizer):
         This method handles:
         1. Hardware acceleration setup (CUDA validation and fallback)
         2. Lazy-loading of the heavyweight ML pipeline.
-
-        :raises ValueError: If model_name is not set
         """
         if self.ner_pipeline is not None:
             return
 
         if not self.model_name:
-            raise ValueError(
-                "model_name must be set before calling load(). "
-                "Pass it to __init__() or set it directly."
-            )
+            logger.info("model_name is not set. Deferring HuggingFace model loading.")
+            return
 
         # Device validation and fallback
         device = self.device
@@ -429,6 +425,13 @@ class HuggingFaceNerRecognizer(LocalRecognizer):
 
         # Defensive guard for entities input
         entities = entities or []
+
+        if not self.model_name:
+            raise ValueError(
+                "model_name must be specified to analyze text using "
+                "HuggingFaceNerRecognizer. Specify model_name when instantiating "
+                "HuggingFaceNerRecognizer or in default_recognizers.yaml."
+            )
 
         if not self.ner_pipeline:
             self.load()

--- a/presidio-analyzer/tests/test_huggingface_ner_recognizer.py
+++ b/presidio-analyzer/tests/test_huggingface_ner_recognizer.py
@@ -256,10 +256,14 @@ def test_hf_recognizer_load_errors():
         with pytest.raises(ImportError):
             HuggingFaceNerRecognizer(model_name="test")
 
-    # 2. Test ValueError when model_name is missing
-    with patch(path, new=MagicMock()):
-        with pytest.raises(ValueError, match="model_name must be set"):
-            HuggingFaceNerRecognizer(model_name=None)
+
+@pytest.mark.usefixtures("mock_torch_installed")
+def test_analyze_without_model_name_raises_with_configuration_pointer():
+    """Verify calling analyze() on HuggingFaceNerRecognizer without model_name raises ValueError with configuration pointer."""
+    with patch(HF_PIPELINE_PATH, new=MagicMock()):
+        recognizer = HuggingFaceNerRecognizer(model_name=None)
+        with pytest.raises(ValueError, match="default_recognizers.yaml"):
+            recognizer.analyze("Some text to analyze", ["PERSON"])
 
 
 @pytest.mark.usefixtures("mock_torch_installed")
@@ -723,3 +727,13 @@ def test_hf_recognizer_resolves_deferred_tokenizer_chunker(mock_pipeline):
     assert chunker.tokenizer is mock_tokenizer
     assert chunker.max_tokens == 128
     assert chunker.overlap_tokens == 16
+
+
+@pytest.mark.usefixtures("mock_torch_installed")
+def test_registry_builds_with_huggingface_entry_enabled():
+    """Verify HuggingFaceNerRecognizer can be instantiated without model_name during registry build."""
+    with patch(HF_PIPELINE_PATH, new=MagicMock()):
+        recognizer = HuggingFaceNerRecognizer()
+        assert recognizer.model_name is None
+        assert recognizer.ner_pipeline is None
+

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -607,15 +607,8 @@ def test_yaml_country_code_blank_value_raises():
 LOADER_KWARGS = ("name", "supported_language")
 
 # Entries that cannot load from their shipped configuration even with every
-# dependency installed, so the load test below cannot cover them.
-#
-# ``HuggingFaceNerRecognizer``: ``EntityRecognizer.__init__`` calls ``load()``
-# unconditionally and ``load()`` requires ``model_name``, which the shipped
-# entry does not supply -- it raises ValueError once ``transformers`` and
-# ``torch`` are present. That is a pre-existing defect in the entry, not
-# something this contract can assert away, and adding ``model_name`` here would
-# make the test download a model. It stays covered by the resolve test.
-NOT_LOADABLE_FROM_SHIPPED_ENTRY = {"HuggingFaceNerRecognizer"}
+# Entries in shipped config that cannot be instantiated from the shipped entry alone.
+NOT_LOADABLE_FROM_SHIPPED_ENTRY = set()
 
 # Entries gated behind an optional dependency, for which refusing to load with an
 # actionable ImportError is the intended behavior. The skip is scoped to these

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -607,8 +607,11 @@ def test_yaml_country_code_blank_value_raises():
 LOADER_KWARGS = ("name", "supported_language")
 
 # Entries that cannot load from their shipped configuration even with every
-# Entries in shipped config that cannot be instantiated from the shipped entry alone.
-NOT_LOADABLE_FROM_SHIPPED_ENTRY = set()
+# dependency installed, so the load test below cannot cover them. Empty today:
+# ``HuggingFaceNerRecognizer`` used to sit here because ``load()`` raised when the
+# shipped entry supplied no ``model_name``. It now defers loading instead, so the
+# load test covers it like every other entry.
+NOT_LOADABLE_FROM_SHIPPED_ENTRY: set[str] = set()
 
 # Entries gated behind an optional dependency, for which refusing to load with an
 # actionable ImportError is the intended behavior. The skip is scoped to these


### PR DESCRIPTION
Fixes #2222

`HuggingFaceNerRecognizer` ships in `default_recognizers.yaml` with `enabled: false` and no `model_name`. Flipping that switch does not work: `EntityRecognizer.__init__` calls `load()`, `load()` raised when `model_name` was unset, and the error therefore arrived during registry construction rather than at analyze time. The shipped entry advertised a toggle that always crashed.

The issue offers three acceptable fixes. I took the deferred-load one:

- `load()` now returns early with an info-level log when `model_name` is unset, so the registry builds.
- `analyze()` raises a `ValueError` naming what is missing and where to set it, including `default_recognizers.yaml`, so the failure surfaces at the point of use with an actionable message.

I deliberately did **not** give the shipped entry a default `model_name`. Committing the project to a specific HuggingFace model reference in shipped config is a product decision rather than a bug fix, and it would make the loader test download a model. Happy to switch to that if you would rather — it is a small change on top of this one.

Because the entry now loads, `HuggingFaceNerRecognizer` has been removed from the `NOT_LOADABLE_FROM_SHIPPED_ENTRY` exclusion in `test_recognizers_loader_utils.py`, which #2170 added with a guard test to keep the gap visible. That set is now empty, and the recognizer is covered by the normal load test like every other entry. I left the comment in place explaining why it is empty, so the next person to need it knows what it was for.

The existing test asserting the old `ValueError` from `load()` is updated to assert the new analyze-time error instead, and a test covers registry construction succeeding with the recognizer instantiated and unloaded.

`presidio-analyzer/tests/test_huggingface_ner_recognizer.py` and `test_recognizers_loader_utils.py`: 338 passed, 3 skipped. `ruff check presidio_analyzer tests` reports all checks passed.
