### PR TITLE
fix: let the shipped HuggingFaceNerRecognizer entry be enabled (#2222)

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/huggingface_ner_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/huggingface_ner_recognizer.py
@@ -258,16 +258,25 @@ class HuggingFaceNerRecognizer(LocalRecognizer):
         1. Hardware acceleration setup (CUDA validation and fallback)
         2. Lazy-loading of the heavyweight ML pipeline.
 
-        :raises ValueError: If model_name is not set
+        Without ``model_name`` the pipeline cannot be built, and this returns
+        without one rather than raising: ``EntityRecognizer.__init__`` calls
+        ``load()``, so raising here aborted the construction of the whole
+        registry for anyone who enabled the shipped
+        ``default_recognizers.yaml`` entry, which carries no ``model_name``.
+        The recognizer is then registered but inactive, and ``analyze()``
+        raises with the same actionable message, so a missing model is still
+        reported rather than silently returning no entities.
         """
         if self.ner_pipeline is not None:
             return
 
         if not self.model_name:
-            raise ValueError(
-                "model_name must be set before calling load(). "
-                "Pass it to __init__() or set it directly."
+            logger.warning(
+                "%s has no model_name and stays inactive. Set model_name to "
+                "use it, either in __init__() or on the recognizer entry.",
+                self.name,
             )
+            return
 
         # Device validation and fallback
         device = self.device
@@ -429,6 +438,17 @@ class HuggingFaceNerRecognizer(LocalRecognizer):
 
         # Defensive guard for entities input
         entities = entities or []
+
+        if not self.model_name:
+            # load() leaves the recognizer inactive in this case, so that the
+            # shipped default_recognizers.yaml entry can be enabled without
+            # aborting the construction of the registry. Raising here rather
+            # than returning [] keeps a misconfigured recognizer from reading
+            # as "this text contains no PII".
+            raise ValueError(
+                "model_name must be set before calling analyze(). "
+                "Pass it to __init__() or set it directly."
+            )
 
         if not self.ner_pipeline:
             self.load()

--- a/presidio-analyzer/tests/test_huggingface_ner_recognizer.py
+++ b/presidio-analyzer/tests/test_huggingface_ner_recognizer.py
@@ -256,10 +256,14 @@ def test_hf_recognizer_load_errors():
         with pytest.raises(ImportError):
             HuggingFaceNerRecognizer(model_name="test")
 
-    # 2. Test ValueError when model_name is missing
+    # 2. Without model_name the recognizer builds but stays inactive, so that
+    # enabling the shipped default_recognizers.yaml entry does not abort the
+    # construction of the registry. The missing model is reported on use.
     with patch(path, new=MagicMock()):
+        recognizer = HuggingFaceNerRecognizer(model_name=None)
+        assert recognizer.ner_pipeline is None
         with pytest.raises(ValueError, match="model_name must be set"):
-            HuggingFaceNerRecognizer(model_name=None)
+            recognizer.analyze("Katherine lives in Seoul", entities=["PERSON"])
 
 
 @pytest.mark.usefixtures("mock_torch_installed")

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import re
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Set
 
 import presidio_analyzer.predefined_recognizers as predefined
 import pytest
@@ -607,15 +607,10 @@ def test_yaml_country_code_blank_value_raises():
 LOADER_KWARGS = ("name", "supported_language")
 
 # Entries that cannot load from their shipped configuration even with every
-# dependency installed, so the load test below cannot cover them.
-#
-# ``HuggingFaceNerRecognizer``: ``EntityRecognizer.__init__`` calls ``load()``
-# unconditionally and ``load()`` requires ``model_name``, which the shipped
-# entry does not supply -- it raises ValueError once ``transformers`` and
-# ``torch`` are present. That is a pre-existing defect in the entry, not
-# something this contract can assert away, and adding ``model_name`` here would
-# make the test download a model. It stays covered by the resolve test.
-NOT_LOADABLE_FROM_SHIPPED_ENTRY = {"HuggingFaceNerRecognizer"}
+# dependency installed, so the load test below cannot cover them. Empty: an
+# entry that cannot be loaded as shipped is a defect in the entry, and keeping
+# the set makes the next one visible here instead of silently untested.
+NOT_LOADABLE_FROM_SHIPPED_ENTRY: Set[str] = set()
 
 # Entries gated behind an optional dependency, for which refusing to load with an
 # actionable ImportError is the intended behavior. The skip is scoped to these


### PR DESCRIPTION
Enabling the shipped `HuggingFaceNerRecognizer` entry in `default_recognizers.yaml` crashes the whole registry build, because the entry carries no `model_name` and `EntityRecognizer.__init__` calls `load()`. The switch exists but can never be turned on.

`load()` now leaves the recognizer inactive and logs why, so the registry builds. `analyze()` raises with the same actionable message, so a recognizer without a model is reported rather than quietly returning no entities, which for a PII library would read as "this text is clean".

The guard in `analyze()` is on `model_name` rather than on a missing pipeline, so lazy loading through `load()` behaves exactly as before.

`HuggingFaceNerRecognizer` can therefore leave `NOT_LOADABLE_FROM_SHIPPED_ENTRY`, where the contract test kept it with a comment calling it a pre-existing defect in the entry. The set stays in place, and empty, so the next entry that cannot load as shipped is visible there instead of silently untested.

Fixes #2222.

Verified locally: the reproduction from the issue now builds a registry containing the recognizer, and using it without a model still explains why. Full analyzer suite passes (3316 passed, 13 skipped); `ruff check` is clean. `ruff format` reports one pre-existing complaint in `tests/test_recognizers_loader_utils.py` that is unrelated to these lines, so I left it alone rather than reformatting untouched code.

Disclosure: this was prepared with an AI coding assistant. The project's full analyzer test suite and linter were run locally before opening this.