### PR TITLE
Add Type-2 NPI Luhn test cases to us_npi_recognizer tests

### DIFF
--- a/presidio-analyzer/tests/test_us_npi_recognizer.py
+++ b/presidio-analyzer/tests/test_us_npi_recognizer.py
@@ -22,8 +22,12 @@ def entities():
         ("1234567893", 1, ((0, 10),), (("max", "max"),),),
         # Another valid NPI
         ("1245319599", 1, ((0, 10),), (("max", "max"),),),
-        # Valid NPI starting with 2 (Type 2 = organization)
+        # Valid NPI (Type 1 = individual)
         ("1003000126", 1, ((0, 10),), (("max", "max"),),),
+        # Valid NPI starting with 2 (Type 2 = organization)
+        ("2123456784", 1, ((0, 10),), (("max", "max"),),),
+        # Invalid: starts with 2 (Type 2) but fails Luhn check → filtered out
+        ("2123456783", 0, (), (),),
         # Formatted NPI with dashes — Luhn validates after stripping → MAX
         ("1234-567-893", 1, ((0, 12),), (("max", "max"),),),
         # Formatted NPI with spaces — Luhn validates after stripping → MAX


### PR DESCRIPTION
The parametrized case labeled "Valid NPI starting with 2 (Type 2 = organization)"
in tests/test_us_npi_recognizer.py actually used `1003000126`, an NPI starting
with `1` (Type 1 = individual). The recognizer's Type-2 (organization) branch had
no dedicated Luhn test coverage.

Per the CMS NPI spec, the check digit is a standard Luhn check computed over the
10-digit NPI prefixed with "80840". I verified the following against the
recognizer's own `__npi_luhn_checksum` implementation:

- `2123456784` — Type 2 (starts with 2), passes Luhn → should be recognized
- `2123456783` — same 9-digit body, invalid check digit, fails Luhn → should be
  filtered out

This PR adds both cases and fixes the comment on the pre-existing case to
correctly say "Type 1".

No source changes — test-only.