### PR TITLE
Fix: Sort entities before merging adjacent same-type entities

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
@@ -221,16 +221,27 @@ class AnonymizerEngine(EngineBase):
         self, text: str, analyzer_results: List[RecognizerResult]
     ) -> List[RecognizerResult]:
         """Merge adjacent entities of the same type separated by whitespace."""
+        if not analyzer_results:
+            return []
+
+        # Sort entities by start position to ensure proper merging
+        sorted_results = sorted(analyzer_results, key=lambda x: x.start)
+        
         merged_results = []
-        prev_result = None
-        for result in analyzer_results:
-            if prev_result is not None:
+        for result in sorted_results:
+            if merged_results:
+                prev_result = merged_results[-1]
                 if prev_result.entity_type == result.entity_type:
                     if re.search(r"^( )+$", text[prev_result.end:result.start]):
-                        merged_results.remove(prev_result)
+                        # Merge: extend the previous entity
                         result.start = prev_result.start
-            merged_results.append(result)
-            prev_result = result
+                        merged_results[-1] = result
+                    else:
+                        merged_results.append(result)
+                else:
+                    merged_results.append(result)
+            else:
+                merged_results.append(result)
         return merged_results
 
     def get_anonymizers(self) -> List[str]:

--- a/presidio-anonymizer/tests/issue_tests/test_merge_unsorted.py
+++ b/presidio-anonymizer/tests/issue_tests/test_merge_unsorted.py
@@ -1,0 +1,36 @@
+import pytest
+from presidio_anonymizer import AnonymizerEngine
+from presidio_analyzer import RecognizerResult
+
+
+def test_merge_entities_when_unsorted():
+    """
+    Test that entities are correctly merged even when the input list
+    is not sorted by start position.
+    This reproduces the bug from Issue #1090 and #1573.
+    """
+    engine = AnonymizerEngine()
+    
+    # The original text
+    text = "My name is Dave Jones"
+    
+    # Create unsorted results: "Jones" (start=16) comes before "Dave" (start=11)
+    # Text: "My name is Dave Jones"
+    #                     ^^^^ (start=11, end=15)
+    #                           ^^^^^ (start=16, end=21)
+    unsorted_results = [
+        RecognizerResult(entity_type="PERSON", start=16, end=21, score=0.85),  # "Jones"
+        RecognizerResult(entity_type="PERSON", start=11, end=15, score=0.85),  # "Dave"
+    ]
+    
+    # Call the internal merge method with both text and analyzer_results
+    merged = engine._merge_entities_with_spaces_between(
+        text=text, 
+        analyzer_results=unsorted_results
+    )
+    
+    # Should merge into ONE entity covering "Dave Jones"
+    assert len(merged) == 1, f"Expected 1 merged entity, got {len(merged)}"
+    assert merged[0].entity_type == "PERSON"
+    assert merged[0].start == 11, f"Expected start=11, got {merged[0].start}"
+    assert merged[0].end == 21, f"Expected end=21, got {merged[0].end}"


### PR DESCRIPTION
## Change Description

### What does this PR do?
- Adds sorting by `start` position in `_merge_entities_with_spaces_between()`
- Ensures entities are merged correctly even when the input list is unsorted
- Fixes the underlying cause of merging failures

### Why is this needed?
- **Issue #1090** requests merging adjacent same-type entities
- **Issue #1573** identified that merging fails when results are unsorted
- Without this fix, anonymization can produce separate `<PERSON>` Rania 

### Example
**Before:**