### PR TITLE
ci: auto-label pull requests by component and area

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -72,6 +72,14 @@ documentation:
           - 'overrides/**'
           - '*.md'
 
+# Runnable examples and notebooks. Overlaps documentation by design: a sample
+# is documentation, but it is also code that has to keep working, so it needs
+# to be findable on its own.
+samples:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/samples/**'
+
 # ---------------------------------------------------------------------------
 # Area (analyzer subsystems)
 # ---------------------------------------------------------------------------

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,9 @@
 # Path-based labels applied automatically by .github/workflows/label-areas.yml
 #
-# Two facets are applied here:
+# Three facets are applied here:
 #   component - which package the change lives in
 #   area      - which subsystem inside the analyzer it touches
+#   type      - what kind of change it is, where the paths make that clear
 #
 # Labels are not exclusive. A pull request that spans a package and a subsystem
 # receives both, which is intended: the component label answers "what does this
@@ -72,14 +73,6 @@ documentation:
           - 'overrides/**'
           - '*.md'
 
-# Runnable examples and notebooks. Overlaps documentation by design: a sample
-# is documentation, but it is also code that has to keep working, so it needs
-# to be findable on its own.
-samples:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'docs/samples/**'
-
 # ---------------------------------------------------------------------------
 # Area (analyzer subsystems)
 # ---------------------------------------------------------------------------
@@ -120,6 +113,14 @@ nlp-engine:
 # ---------------------------------------------------------------------------
 # Type
 # ---------------------------------------------------------------------------
+
+# Runnable examples and notebooks. Overlaps documentation by design: a sample
+# is documentation, but it is also code that has to keep working, so it needs
+# to be findable on its own.
+samples:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/samples/**'
 
 test:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,132 @@
+# Path-based labels applied automatically by .github/workflows/label-areas.yml
+#
+# Two facets are applied here:
+#   component - which package the change lives in
+#   area      - which subsystem inside the analyzer it touches
+#
+# Labels are not exclusive. A pull request that spans a package and a subsystem
+# receives both, which is intended: the component label answers "what does this
+# release affect", the area label answers "who should review it".
+#
+# Triage labels (needs-decision, good first issue, ...) are applied by hand and
+# must not be listed here, or sync-labels would eventually remove them.
+
+# ---------------------------------------------------------------------------
+# Component
+# ---------------------------------------------------------------------------
+
+analyzer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-analyzer/**'
+          - 'docs/analyzer/**'
+
+anonymizer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-anonymizer/**'
+          - 'docs/anonymizer/**'
+
+image-anonymization:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-image-redactor/**'
+          - 'docs/image-redactor/**'
+
+dicom:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/dicom_*.py'
+          - '**/*dicom*'
+
+structured-data:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-structured/**'
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-cli/**'
+
+rest-api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-*/app.py'
+          - 'docs/api-docs/**'
+          - 'docs/api.md'
+
+deployment:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/Dockerfile*'
+          - 'docker-compose*.yml'
+          - 'presidio/**'
+          - 'scripts/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'mkdocs.yml'
+          - 'overrides/**'
+          - '*.md'
+
+# ---------------------------------------------------------------------------
+# Area (analyzer subsystems)
+# ---------------------------------------------------------------------------
+
+# Pattern and predefined recognizers.
+# Review rulebook: .github/instructions/recognizers.instructions.md
+PII recognizers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-analyzer/presidio_analyzer/predefined_recognizers/**'
+          - 'presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml'
+          - 'docs/supported_entities.md'
+
+# Score boosting from surrounding words, including the lemma matching that
+# behaves differently per language.
+context-enhancement:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-analyzer/presidio_analyzer/context_aware_enhancers/**'
+
+# The pydantic models and registry loading behind YAML configuration.
+# Review rulebook: .github/instructions/yaml-config.instructions.md
+yaml-config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-analyzer/presidio_analyzer/input_validation/**'
+          - 'presidio-analyzer/presidio_analyzer/recognizer_registry/**'
+          - 'presidio-analyzer/presidio_analyzer/conf/**'
+
+# NLP backends: spaCy, Stanza, transformers, GLiNER, LangExtract.
+nlp-engine:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'presidio-analyzer/presidio_analyzer/nlp_engine/**'
+          - 'presidio-analyzer/presidio_analyzer/chunkers/**'
+          - 'presidio-analyzer/presidio_analyzer/llm_utils/**'
+
+# ---------------------------------------------------------------------------
+# Type
+# ---------------------------------------------------------------------------
+
+test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/tests/**'
+          - 'e2e-tests/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/pipelines/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/pyproject.toml'
+          - '**/uv.lock'

--- a/.github/workflows/label-areas.yml
+++ b/.github/workflows/label-areas.yml
@@ -1,0 +1,29 @@
+name: Label pull requests by area
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# pull_request_target is required so that pull requests from forks receive a
+# token with write access; a pull_request event grants read-only on forks and
+# the label call fails silently.
+#
+# The usual pull_request_target risk does not apply here: this workflow never
+# checks out or executes pull request code. It reads the changed file list
+# through the API only, and both this file and .github/labeler.yml are read
+# from the base branch, so a pull request cannot change its own label rules.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Apply component and area labels from changed paths
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+        with:
+          # Add labels only. Labels applied by hand are never removed, and a
+          # pull request that stops touching a path keeps the label a reviewer
+          # may already have acted on.
+          sync-labels: false

--- a/.github/workflows/label-areas.yml
+++ b/.github/workflows/label-areas.yml
@@ -1,4 +1,4 @@
-name: Label pull requests by area
+name: Label pull requests by changed paths
 
 on:
   pull_request_target:
@@ -20,7 +20,7 @@ jobs:
   label:
     runs-on: ubuntu-slim
     steps:
-      - name: Apply component and area labels from changed paths
+      - name: Apply component, area and type labels from changed paths
         uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           # Add labels only. Labels applied by hand are never removed, and a


### PR DESCRIPTION
## Change Description

Adds `actions/labeler` so every pull request is labelled from its changed paths, instead of being triaged by hand.

Two new files:

- `.github/labeler.yml` — path rules across three facets: component (which package), area (which analyzer subsystem), and type (`samples`, `test`, `ci`, `dependencies`).
- `.github/workflows/label-areas.yml` — runs the labeler on `opened`, `synchronize` and `reopened`.

**No behavior change to any Presidio package.** This only affects repository automation.

### Why this is worth doing

The immediate goal is a project board of open pull requests grouped by topic, so triage starts from "what is in each area" rather than a flat list of 50-plus pull requests. A board needs a reliable grouping key, and today there is none: the areas that actually generate the most work — YAML configuration and registry loading, context enhancement, NLP backends — have no label to group or filter on.

This change supplies that key. Once the labels are populated, the board can be built on top in either form:

- Saved views filtered by label (`is:open is:pr label:yaml-config`), which needs no further setup.
- A GitHub Project with a `Topic` single-select field mirroring the area labels, auto-populated by the built-in `is:pr is:open` add workflow.

Labelling every pull request by hand would not sustain either one, which is why this is automated rather than a one-off pass.

### Why `pull_request_target`

Same reason `label-external.yml` already uses it: on a `pull_request` event from a fork, GitHub issues a read-only token and the label call fails silently. The usual `pull_request_target` risk does not apply here, because the action never checks out or executes pull request code — it reads the changed-file list through the API — and both the workflow and `labeler.yml` are read from the base branch, so a pull request cannot change the rules that label it.

`sync-labels` is left at `false`, so labels applied by hand are never stripped.

### Labels

All 17 label names the config references now exist in the repository, so the labeler reuses them and creates nothing implicitly. Ten were already in use (`analyzer`, `anonymizer`, `image-anonymization`, `dicom`, `structured-data`, `documentation`, `samples`, `deployment`, `dependencies`, `PII recognizers`). Seven were added for this change:

| Label | Covers | Open PRs today |
|---|---|---|
| `context-enhancement` | `context_aware_enhancers/**` | 4 |
| `yaml-config` | `input_validation/**`, `recognizer_registry/**`, `conf/**` | 8 |
| `nlp-engine` | `nlp_engine/**`, `chunkers/**`, `llm_utils/**` | 5 |
| `rest-api` | `presidio-*/app.py`, `docs/api-docs/**` | 3 |
| `cli` | `presidio-cli/**` | 0 |
| `test` | `**/tests/**`, `e2e-tests/**` | — |
| `ci` | `.github/workflows/**`, `.github/pipelines/**` | — |

`context-enhancement` and `yaml-config` are named to match the review rulebooks in `.github/instructions/`, so the label tells a reviewer which instruction file applies to the change.

### Notes for review

- Labels are not exclusive by design. A pull request spanning a package and a subsystem gets both: the component label answers what a release affects, the area label answers who should review it. A change under `docs/samples/**` gets both `samples` and `documentation` for the same reason — a sample is documentation, but it is also code that has to keep working.
- `analyzer` will match nearly every analyzer pull request, including recognizer and YAML-config ones. That is intended — filtering happens on the area labels.
- The labeler acts on events only, so it does not touch the currently open pull requests. Back-labelling those is a separate one-off pass, and is what makes the first board useful on day one rather than after the backlog turns over.
- Label renames for casing consistency (`PII recognizers`, `Performance`, `Advanced`) are deliberately left out of this change, since renames happen in repository settings rather than in a diff.
- `actions/labeler` is pinned to the commit SHA for v6.2.0, matching the convention in `label-external.yml` and the request in #2230.

## Issue reference

No existing issue. Proposed while reviewing the open pull request and issue backlog, as the prerequisite for a topic-based board of open pull requests.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [ ] My code includes unit tests — not applicable; the change is workflow configuration with no Python code. Both YAML files were validated as parsing.
- [x] All unit tests and lint checks pass locally — no Python source changed, so no test or lint surface is affected.
- [x] My PR contains documentation updates / additions if required — the rules are documented in comments inside `labeler.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183ij1wiTEcd8wA58xY7e6C