### PR TITLE
fix(images): harden analyzer and anonymizer container images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,166 @@
+name: Build and Push Images
+
+# Reusable image build. Called by release.yml when cutting a release and by
+# rebuild-images.yml on a schedule, so that published images pick up base image
+# security updates without waiting for the next release.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Tag applied to the analyzer, anonymizer and CLI-adjacent images.
+        required: true
+        type: string
+      image-version:
+        description: Tag applied to the image-redactor image.
+        required: true
+        type: string
+      date-tag:
+        description: >
+          Optional immutable suffix, e.g. 20260909. When set, each image is also
+          pushed as <version>-<date-tag> so a specific rebuild can be pinned or
+          rolled back to.
+        required: false
+        default: ''
+        type: string
+
+permissions: read-all
+
+env:
+  IMAGE_REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: data-privacy-stack
+
+jobs:
+  build-and-push-containers:
+    name: Build and Push ${{ matrix.image }}${{ matrix.tag_suffix }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
+        platform: [linux/amd64, linux/arm64]
+        variant: [default, distroless]
+        exclude:
+          # No distroless variant is published for the image-redactor: it
+          # depends on the Tesseract OCR system packages, which are not
+          # available in a distroless base image.
+          - image: presidio-image-redactor
+            variant: distroless
+        include:
+          - platform: linux/amd64
+            platform_tag: linux-amd64
+          - platform: linux/arm64
+            platform_tag: linux-arm64
+          - variant: default
+            dockerfile: Dockerfile
+            tag_suffix: ''
+          - variant: distroless
+            dockerfile: Dockerfile.distroless
+            tag_suffix: -distroless
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
+        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and Push ${{ matrix.image }}${{ matrix.tag_suffix }} for ${{ matrix.platform }}
+        run: |
+          set -eu
+          repo="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${{ matrix.image }}"
+          version_tag="${VERSION}"
+          if [ "${{ matrix.image }}" = "presidio-image-redactor" ]; then
+            version_tag="${IMAGE_VERSION}"
+          fi
+          suffix="${{ matrix.tag_suffix }}"
+          platform_tag="${{ matrix.platform_tag }}"
+
+          tag_args="--tag ${repo}:latest${suffix}-${platform_tag}"
+          tag_args="${tag_args} --tag ${repo}:${version_tag}${suffix}-${platform_tag}"
+          if [ -n "${DATE_TAG}" ]; then
+            tag_args="${tag_args} --tag ${repo}:${version_tag}-${DATE_TAG}${suffix}-${platform_tag}"
+          fi
+
+          # shellcheck disable=SC2086
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --file ./${{ matrix.image }}/${{ matrix.dockerfile }} \
+            --cache-from type=registry,ref=${repo}:latest${suffix} \
+            --cache-to type=inline \
+            ${tag_args} \
+            --attest type=sbom \
+            --attest type=provenance,mode=max \
+            --push \
+            ./${{ matrix.image }}
+        env:
+          VERSION: ${{ inputs.version }}
+          IMAGE_VERSION: ${{ inputs.image-version }}
+          DATE_TAG: ${{ inputs.date-tag }}
+
+  create-container-manifests:
+    name: Create Multi-Platform Container Manifests
+    runs-on: ubuntu-latest
+    needs: build-and-push-containers
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
+        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Create multi-platform manifests
+        run: |
+          set -eu
+          images=(presidio-anonymizer presidio-analyzer presidio-image-redactor)
+          platform_tags=(linux-amd64 linux-arm64)
+
+          for image in "${images[@]}"; do
+            repo="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${image}"
+            version_tag="${VERSION}"
+            suffixes=("" "-distroless")
+            if [ "${image}" = "presidio-image-redactor" ]; then
+              version_tag="${IMAGE_VERSION}"
+              suffixes=("")
+            fi
+
+            for suffix in "${suffixes[@]}"; do
+              tags=("latest${suffix}" "${version_tag}${suffix}")
+              if [ -n "${DATE_TAG}" ]; then
+                tags+=("${version_tag}-${DATE_TAG}${suffix}")
+              fi
+
+              for tag in "${tags[@]}"; do
+                platform_refs=()
+                for platform_tag in "${platform_tags[@]}"; do
+                  platform_refs+=("${repo}:${tag}-${platform_tag}")
+                done
+
+                docker buildx imagetools create \
+                  --tag "${repo}:${tag}" \
+                  "${platform_refs[@]}"
+              done
+            done
+          done
+        env:
+          VERSION: ${{ inputs.version }}
+          IMAGE_VERSION: ${{ inputs.image-version }}
+          DATE_TAG: ${{ inputs.date-tag }}

--- a/.github/workflows/rebuild-images.yml
+++ b/.github/workflows/rebuild-images.yml
@@ -1,0 +1,71 @@
+name: Rebuild Images
+
+# Published images pin their base image by digest, so they never pick up
+# operating system security updates on their own. Rebuilding on a schedule
+# republishes the same versions on top of a freshly patched base, which is what
+# container compliance scanners expect ("redeploy the image", "update the
+# vulnerable image reference").
+#
+# Rebuilds do not change any application code: the workflow builds the current
+# state of main and republishes the `latest` and current version tags, plus an
+# immutable `<version>-<date>` tag so a specific rebuild can be pinned.
+
+on:
+  schedule:
+    # Every Monday at 05:00 UTC.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  get-version:
+    name: Get Version Numbers
+    runs-on: ubuntu-slim
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+      image-version: ${{ steps.set-image-version.outputs.image-version }}
+      date-tag: ${{ steps.set-date-tag.outputs.date-tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Extract main version
+        id: set-version
+        run: |
+          set -eu
+          ver=$(grep -m 1 version presidio-analyzer/pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
+          echo "version=$ver" >> $GITHUB_OUTPUT
+          echo "Main version: $ver"
+
+      - name: Extract image-redactor version
+        id: set-image-version
+        run: |
+          set -eu
+          imageVer=$(grep -m 1 version presidio-image-redactor/pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
+          echo "image-version=$imageVer" >> $GITHUB_OUTPUT
+          echo "Image-redactor version: $imageVer"
+
+      - name: Set date tag
+        id: set-date-tag
+        run: |
+          set -eu
+          dateTag=$(date -u +'%Y%m%d')
+          echo "date-tag=$dateTag" >> $GITHUB_OUTPUT
+          echo "Date tag: $dateTag"
+
+  rebuild-and-push-containers:
+    name: Rebuild and Push Container Images
+    needs: get-version
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/build-images.yml
+    with:
+      version: ${{ needs.get-version.outputs.version }}
+      image-version: ${{ needs.get-version.outputs.image-version }}
+      date-tag: ${{ needs.get-version.outputs.date-tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
 
 permissions: read-all
 
-env:
-  IMAGE_REGISTRY: ghcr.io
-  IMAGE_NAMESPACE: data-privacy-stack
-
 jobs:
   get-version:
     name: Get Version Numbers
@@ -114,101 +110,14 @@ jobs:
           skip-existing: true
 
   build-and-push-containers:
-    name: Build and Push ${{ matrix.image }} (${{ matrix.platform }})
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: Build and Push Container Images
     needs: get-version
     permissions:
       contents: read
       packages: write
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
-        platform: [linux/amd64, linux/arm64]
-        include:
-          - platform: linux/amd64
-            platform_tag: linux-amd64
-          - platform: linux/arm64
-            platform_tag: linux-arm64
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
-        with:
-          persist-credentials: false
-
-      - name: Log in to GitHub Container Registry
-        env:
-          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
-        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build and Push ${{ matrix.image }} for ${{ matrix.platform }}
-        run: |
-          repo="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${{ matrix.image }}"
-          version_tag="${VERSION}"
-          if [ "${{ matrix.image }}" = "presidio-image-redactor" ]; then
-            version_tag="${IMAGE_VERSION}"
-          fi
-
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --cache-from type=registry,ref=${repo}:latest \
-            --cache-to type=inline \
-            --tag "${repo}:latest-${{ matrix.platform_tag }}" \
-            --tag "${repo}:${version_tag}-${{ matrix.platform_tag }}" \
-            --attest type=sbom \
-            --attest type=provenance,mode=max \
-            --push \
-            ./${{ matrix.image }}
-        env:
-          VERSION: ${{ needs.get-version.outputs.version }}
-          IMAGE_VERSION: ${{ needs.get-version.outputs.image-version }}
-
-  create-container-manifests:
-    name: Create Multi-Platform Container Manifests
-    runs-on: ubuntu-latest
-    needs: [get-version, build-and-push-containers]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Log in to GitHub Container Registry
-        env:
-          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
-        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Create multi-platform manifests
-        run: |
-          images=(presidio-anonymizer presidio-analyzer presidio-image-redactor)
-          platform_tags=(linux-amd64 linux-arm64)
-
-          for image in "${images[@]}"; do
-            repo="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${image}"
-            version_tag="${VERSION}"
-            if [ "${image}" = "presidio-image-redactor" ]; then
-              version_tag="${IMAGE_VERSION}"
-            fi
-
-            for tag in latest "${version_tag}"; do
-              platform_refs=()
-              for platform_tag in "${platform_tags[@]}"; do
-                platform_refs+=("${repo}:${tag}-${platform_tag}")
-              done
-
-              docker buildx imagetools create \
-                --tag "${repo}:${tag}" \
-                "${platform_refs[@]}"
-            done
-          done
-        env:
-          VERSION: ${{ needs.get-version.outputs.version }}
-          IMAGE_VERSION: ${{ needs.get-version.outputs.image-version }}
+    uses: ./.github/workflows/build-images.yml
+    with:
+      version: ${{ needs.get-version.outputs.version }}
+      image-version: ${{ needs.get-version.outputs.image-version }}
+    secrets: inherit

--- a/docs/build_release.md
+++ b/docs/build_release.md
@@ -41,6 +41,25 @@ If an existing deployment uses `mcr.microsoft.com/presidio-analyzer:latest`, tre
 
 Docker registries do not provide a portable way to redirect `docker pull mcr.microsoft.com/presidio-analyzer:latest` to GHCR or show a deprecation warning during `docker pull`. To reduce confusion, each GitHub release includes the GHCR image names, the GHCR images include OCI metadata labels pointing to the source repository, package page, and installation guide, and the MCR tags are documented as legacy references.
 
+### Image variants
+
+Each analyzer and anonymizer tag is published in two variants, built from `Dockerfile` and `Dockerfile.distroless` in the corresponding package directory:
+
+| Variant | Tag | Base image | Notes |
+| --- | --- | --- | --- |
+| Default | `latest`, `<release-version>` | `python:3.12-slim` / `python:3.14-slim` (Debian) | Includes a shell; configured with `PORT` and `WORKERS`. |
+| Distroless | `latest-distroless`, `<release-version>-distroless` | `mcr.microsoft.com/azurelinux/distroless/python:3.12-nonroot` | No shell, package manager or build tooling; configured with `GUNICORN_CMD_ARGS`; runs as UID 65532. |
+
+`presidio-image-redactor` is published in the default variant only, because it depends on the Tesseract OCR system packages.
+
+Neither runtime image contains `pip`, `uv`, `setuptools`, `wheel` or `curl`. Build tooling is confined to the builder stage of each multi-stage build, and the container health check uses the Python standard library instead of `curl`, which would otherwise pull in a large TLS and authentication dependency tree.
+
+### Scheduled rebuilds
+
+Base images are pinned by digest, so a published image never picks up operating system security updates on its own. The `Rebuild Images` workflow (`.github/workflows/rebuild-images.yml`) runs every Monday, and on demand via `workflow_dispatch`. It rebuilds the current state of `main` on a freshly patched base and republishes the `latest` and current version tags, plus an immutable `<version>-<date>` tag, for example `2.2.364-20260909-distroless`, so a specific rebuild can be pinned or rolled back to.
+
+Rebuilds publish no new application code: only the base image layers and any dependency wheels resolved at build time change. Both the release workflow and the rebuild workflow delegate to the reusable `.github/workflows/build-images.yml` workflow, so the two paths cannot drift apart.
+
 ## PyPI publishing with OIDC
 
 The release workflow uses OIDC (OpenID Connect) trusted publishing to PyPI, which eliminates the need to manage PyPI API tokens. This requires:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,6 +132,64 @@ docker run -d -p 5003:3000 ghcr.io/data-privacy-stack/presidio-image-redactor:la
 Once the services are running, their APIs are available.
 API reference and example calls can be found [here](api.md).
 
+### Hardened distroless images
+
+Both `presidio-analyzer` and `presidio-anonymizer` are also published as
+distroless variants, built on
+[Microsoft Azure Linux distroless](https://github.com/microsoft/azurelinux).
+They are functionally identical to the default images, but ship no shell, no
+package manager and no build tooling, which removes almost the entire operating
+system attack surface.
+
+Use them if your organization runs container vulnerability or compliance
+scanning (for example Microsoft Defender for Cloud or S360) against the Presidio
+images.
+
+```sh
+docker pull ghcr.io/data-privacy-stack/presidio-analyzer:latest-distroless
+docker pull ghcr.io/data-privacy-stack/presidio-anonymizer:latest-distroless
+
+docker run -d -p 5002:3000 ghcr.io/data-privacy-stack/presidio-analyzer:latest-distroless
+docker run -d -p 5001:3000 ghcr.io/data-privacy-stack/presidio-anonymizer:latest-distroless
+```
+
+The distroless variants differ from the default images in three ways:
+
+* **No shell.** The `PORT` and `WORKERS` environment variables are not used,
+  because there is no shell to expand them. Gunicorn is started directly, and is
+  configured through `GUNICORN_CMD_ARGS`, which defaults to
+  `--workers=1 --bind=0.0.0.0:3000`:
+
+    ```sh
+    docker run -d -p 5001:3000 \
+      -e GUNICORN_CMD_ARGS="--workers=4 --bind=0.0.0.0:3000 --timeout=120" \
+      ghcr.io/data-privacy-stack/presidio-anonymizer:latest-distroless
+    ```
+
+    For the same reason, `docker exec ... sh` is not available. Use the default
+    images if you need to run commands inside the container.
+
+* **Python 3.12.** Azure Linux distroless publishes Python 3.12 only. This
+  matches the default analyzer image; the default anonymizer image runs Python
+  3.14. Both packages support Python 3.10 through 3.14, so the runtime version
+  does not change behavior.
+
+* **Runs as UID 65532**, the base image's `nonroot` user, rather than UID 1001.
+  Adjust any volume permissions or Kubernetes `runAsUser` settings accordingly.
+
+There is no distroless variant of `presidio-image-redactor`: it depends on the
+Tesseract OCR system packages, which a distroless base image cannot provide.
+
+### Keeping images patched
+
+Images pin their base image by digest, so a published image never picks up
+operating system security updates on its own. The
+[Rebuild Images](https://github.com/data-privacy-stack/presidio/actions/workflows/rebuild-images.yml)
+workflow rebuilds and republishes every image weekly on top of a freshly patched
+base, without changing any application code. Each rebuild also publishes an
+immutable `<version>-<date>` tag, for example `2.2.364-20260909-distroless`, so
+you can pin an exact rebuild and roll back to it if needed.
+
 ## Install from source
 
 To install Presidio from source, first clone the repo:

--- a/presidio-analyzer/Dockerfile
+++ b/presidio-analyzer/Dockerfile
@@ -1,29 +1,18 @@
-FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286
+# ---- builder: uv and the build toolchain exist only in this stage ----
+FROM python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea AS builder
 
 ARG NLP_CONF_FILE=presidio_analyzer/conf/default.yaml
 ARG ANALYZER_CONF_FILE=presidio_analyzer/conf/default_analyzer.yaml
-ARG RECOGNIZER_REGISTRY_CONF_FILE=presidio_analyzer/conf/default_recognizers.yaml
 ENV PIP_NO_CACHE_DIR=1
 # Install the locked dependencies into the system environment (no venv).
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
+ENV UV_COMPILE_BYTECODE=1
 
-ENV ANALYZER_CONF_FILE=${ANALYZER_CONF_FILE}
-ENV RECOGNIZER_REGISTRY_CONF_FILE=${RECOGNIZER_REGISTRY_CONF_FILE}
-ENV NLP_CONF_FILE=${NLP_CONF_FILE}
-
-ENV PORT=3000
-ENV WORKERS=1
-
-COPY ${ANALYZER_CONF_FILE} /app/${ANALYZER_CONF_FILE}
-COPY ${RECOGNIZER_REGISTRY_CONF_FILE} /app/${RECOGNIZER_REGISTRY_CONF_FILE}
-COPY ${NLP_CONF_FILE} /app/${NLP_CONF_FILE}
+# uv is copied in as a static binary rather than installed with pip, so it never
+# reaches the runtime image and its advisories never apply to it.
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/local/bin/uv
 
 WORKDIR /app
-
-# Install essential build tools and curl for health checks
-RUN apt-get update \
-  && apt-get install curl --no-install-recommends -y \
-  && rm -rf /var/lib/apt/lists/*
 
 COPY ./pyproject.toml ./uv.lock /app/
 
@@ -31,15 +20,55 @@ COPY ./pyproject.toml ./uv.lock /app/
 # group, project itself not installed — it is run from the copied source).
 # Splitting this from the source COPY keeps the dependency layer cached until
 # pyproject.toml/uv.lock change.
-RUN pip install uv==0.11.6 \
-    && uv sync --locked --no-cache --no-default-groups --extra server --no-install-project
-    
+RUN uv sync --locked --no-cache --no-default-groups --extra server --no-install-project
+
 # install nlp models specified in NLP_CONF_FILE or via nlp_configuration in ANALYZER_CONF_FILE
+COPY ${ANALYZER_CONF_FILE} /app/${ANALYZER_CONF_FILE}
+COPY ${NLP_CONF_FILE} /app/${NLP_CONF_FILE}
 COPY ./install_nlp_models.py /app/
 
 RUN python install_nlp_models.py \
     --conf_file ${NLP_CONF_FILE} \
     --analyzer_conf_file ${ANALYZER_CONF_FILE}
+
+# ---- runtime ----
+FROM python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea AS runtime
+
+ARG NLP_CONF_FILE=presidio_analyzer/conf/default.yaml
+ARG ANALYZER_CONF_FILE=presidio_analyzer/conf/default_analyzer.yaml
+ARG RECOGNIZER_REGISTRY_CONF_FILE=presidio_analyzer/conf/default_recognizers.yaml
+
+ENV ANALYZER_CONF_FILE=${ANALYZER_CONF_FILE}
+ENV RECOGNIZER_REGISTRY_CONF_FILE=${RECOGNIZER_REGISTRY_CONF_FILE}
+ENV NLP_CONF_FILE=${NLP_CONF_FILE}
+
+ENV PORT=3000
+ENV WORKERS=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Apply every Debian security update published since the base image was built.
+# curl is deliberately not installed: it was only used by the health check, and
+# it pulls in a large TLS/auth dependency tree (gnutls, krb5, libssh2, nghttp2,
+# libtasn1, ldap, sasl) that dominates the image's vulnerability count.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Remove the Python packaging tooling. It is only needed at build time, and this
+# must run after every COPY from the builder: copying /usr/local/bin would
+# otherwise reinstate the binaries that were just removed.
+RUN python -m pip uninstall -y pip setuptools wheel 2>/dev/null || true \
+    && rm -rf /usr/local/bin/pip* /usr/local/bin/uv* /usr/local/bin/wheel \
+    /usr/local/lib/python3.12/site-packages/pip* \
+    /usr/local/lib/python3.12/site-packages/setuptools* \
+    /usr/local/lib/python3.12/site-packages/wheel* \
+    /usr/local/lib/python3.12/site-packages/_distutils_hack \
+    /usr/local/lib/python3.12/site-packages/distutils-precedence.pth
+
+WORKDIR /app
 
 COPY . /app/
 
@@ -49,6 +78,7 @@ RUN useradd -m -u 1001 presidio && chown -R presidio:presidio /app
 USER 1001
 
 EXPOSE ${PORT}
+# Uses the Python standard library rather than curl, which is no longer installed.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:${PORT}/health || exit 1
+    CMD python -c "import os,urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:'+os.environ['PORT']+'/health',timeout=2).status==200 else 1)"
 CMD ["./entrypoint.sh"]

--- a/presidio-analyzer/Dockerfile
+++ b/presidio-analyzer/Dockerfile
@@ -9,8 +9,10 @@ ENV UV_PROJECT_ENVIRONMENT=/usr/local
 ENV UV_COMPILE_BYTECODE=1
 
 # uv is copied in as a static binary rather than installed with pip, so it never
-# reaches the runtime image and its advisories never apply to it.
-COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/local/bin/uv
+# reaches the runtime image and its advisories never apply to it. It is staged in
+# /usr/bin, outside the /usr/local tree the runtime stage copies from, so the
+# ~45MB binary is never baked into a runtime layer.
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/bin/uv
 
 WORKDIR /app
 
@@ -30,6 +32,17 @@ COPY ./install_nlp_models.py /app/
 RUN python install_nlp_models.py \
     --conf_file ${NLP_CONF_FILE} \
     --analyzer_conf_file ${ANALYZER_CONF_FILE}
+
+# Strip packaging tooling here, after the spacy model download (which shells out
+# to pip), so the layers the runtime stage copies never contain it. The runtime
+# stage repeats the removal for the copies that ship in its own base image.
+RUN python -m pip uninstall -y pip setuptools wheel 2>/dev/null || true \
+    && rm -rf /usr/local/bin/pip* /usr/local/bin/wheel \
+    /usr/local/lib/python3.12/site-packages/pip* \
+    /usr/local/lib/python3.12/site-packages/setuptools* \
+    /usr/local/lib/python3.12/site-packages/wheel* \
+    /usr/local/lib/python3.12/site-packages/_distutils_hack \
+    /usr/local/lib/python3.12/site-packages/distutils-precedence.pth
 
 # ---- runtime ----
 FROM python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea AS runtime

--- a/presidio-analyzer/Dockerfile.distroless
+++ b/presidio-analyzer/Dockerfile.distroless
@@ -1,0 +1,86 @@
+# Hardened distroless variant of the presidio-analyzer service.
+#
+# Built on Microsoft Azure Linux distroless, which ships no shell, no package
+# manager and no build tooling, so the resulting image has a far smaller
+# vulnerability surface than the Debian slim variant. See ../docs/installation.md
+# for the behavioural differences between the two variants.
+#
+# Behavioural differences vs. ./Dockerfile:
+#   * No shell, so entrypoint.sh cannot run. Gunicorn is started directly and
+#     configured through GUNICORN_CMD_ARGS instead of the PORT/WORKERS variables.
+#   * Runs as the base image's nonroot user, UID 65532.
+
+# ---- builder: pip and build tooling exist only in this stage ----
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS builder
+
+# Optional alternate package index for environments without direct PyPI access.
+# Left empty by default so public builds use PyPI.
+ARG PIP_INDEX_URL
+ARG NLP_CONF_FILE=presidio_analyzer/conf/default.yaml
+ARG ANALYZER_CONF_FILE=presidio_analyzer/conf/default_analyzer.yaml
+ENV PIP_INDEX_URL=${PIP_INDEX_URL} \
+    PIP_NO_CACHE_DIR=1
+
+# A virtualenv is required rather than `pip install --prefix`: spacy's model
+# download shells out to pip, which ignores --prefix and would install the
+# models into the wrong tree. The service then fails at startup because the
+# model package cannot be imported.
+RUN python3 -m venv /opt/venv
+ENV PATH=/opt/venv/bin:$PATH \
+    VIRTUAL_ENV=/opt/venv
+
+WORKDIR /src
+
+COPY pyproject.toml ./
+COPY presidio_analyzer ./presidio_analyzer
+
+# .dockerignore excludes *.md, but pyproject.toml declares a readme, so the
+# build backend needs a placeholder to resolve project metadata.
+RUN printf "# presidio-analyzer\n" > README.md \
+    && pip install --no-cache-dir ".[server]"
+
+# Install the NLP models declared in NLP_CONF_FILE, or via nlp_configuration
+# in ANALYZER_CONF_FILE.
+COPY install_nlp_models.py ./
+RUN python install_nlp_models.py \
+    --conf_file ${NLP_CONF_FILE} \
+    --analyzer_conf_file ${ANALYZER_CONF_FILE}
+
+# Packaging tooling is only needed at build time. Removing it here keeps future
+# pip/setuptools/wheel advisories from landing on the runtime image.
+RUN pip uninstall -y pip setuptools wheel 2>/dev/null || true
+
+# ---- runtime ----
+FROM mcr.microsoft.com/azurelinux/distroless/python:3.12-nonroot AS runtime
+
+# The distroless image has no shell, so gunicorn is invoked directly. Override
+# workers, bind address or any other gunicorn setting via GUNICORN_CMD_ARGS.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    GUNICORN_CMD_ARGS="--workers=1 --bind=0.0.0.0:3000" \
+    ANALYZER_CONF_FILE=presidio_analyzer/conf/default_analyzer.yaml \
+    RECOGNIZER_REGISTRY_CONF_FILE=presidio_analyzer/conf/default_recognizers.yaml \
+    NLP_CONF_FILE=presidio_analyzer/conf/default.yaml
+
+COPY --from=builder /opt/venv/lib/python3.12/site-packages /usr/lib/python3.12/site-packages
+
+WORKDIR /app
+
+# The service is served from the copied source tree, which precedes
+# site-packages on sys.path. logging.ini is required: gunicorn fails to start
+# without it.
+COPY app.py logging.ini ./
+COPY presidio_analyzer ./presidio_analyzer
+
+USER 65532
+
+EXPOSE 3000
+
+# curl is unavailable (and would pull in a large TLS/auth dependency tree), so
+# the health check uses the Python standard library instead. Loading the spaCy
+# model takes noticeably longer than the anonymizer's startup, hence the longer
+# start period.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=5 \
+    CMD ["/usr/bin/python3", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://localhost:3000/health',timeout=3).status==200 else 1)"]
+
+ENTRYPOINT ["/usr/bin/python3", "-m", "gunicorn", "app:create_app()"]

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -1,22 +1,52 @@
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+# ---- builder: uv and the build toolchain exist only in this stage ----
+FROM python:3.14-slim@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6 AS builder
 
 ENV PIP_NO_CACHE_DIR=1
 # Install the locked dependencies into the system environment (no venv).
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
+ENV UV_COMPILE_BYTECODE=1
 
-ENV PORT=3000
-ENV WORKERS=1
+# uv is copied in as a static binary rather than installed with pip, so it never
+# reaches the runtime image and its advisories never apply to it.
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/local/bin/uv
 
 WORKDIR /app
-
-# Install curl for health checks
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY ./pyproject.toml ./uv.lock /app/
 # Install exactly the locked dependency graph (main + server extra, no dev
 # group); the project itself is run from the copied source, not installed.
-RUN pip install uv==0.11.6 \
-    && uv sync --locked --no-cache --no-default-groups --extra server --no-install-project
+RUN uv sync --locked --no-cache --no-default-groups --extra server --no-install-project
+
+# ---- runtime ----
+FROM python:3.14-slim@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6 AS runtime
+
+ENV PORT=3000
+ENV WORKERS=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Apply every Debian security update published since the base image was built.
+# curl is deliberately not installed: it was only used by the health check, and
+# it pulls in a large TLS/auth dependency tree (gnutls, krb5, libssh2, nghttp2,
+# libtasn1, ldap, sasl) that dominates the image's vulnerability count.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Remove the Python packaging tooling. It is only needed at build time, and this
+# must run after every COPY from the builder: copying /usr/local/bin would
+# otherwise reinstate the binaries that were just removed.
+RUN python -m pip uninstall -y pip setuptools wheel 2>/dev/null || true \
+    && rm -rf /usr/local/bin/pip* /usr/local/bin/uv* /usr/local/bin/wheel \
+    /usr/local/lib/python3.14/site-packages/pip* \
+    /usr/local/lib/python3.14/site-packages/setuptools* \
+    /usr/local/lib/python3.14/site-packages/wheel* \
+    /usr/local/lib/python3.14/site-packages/_distutils_hack \
+    /usr/local/lib/python3.14/site-packages/distutils-precedence.pth
+
+WORKDIR /app
 
 COPY . /app/
 
@@ -26,6 +56,7 @@ RUN useradd -m -u 1001 presidio && chown -R presidio:presidio /app
 USER 1001
 
 EXPOSE ${PORT}
+# Uses the Python standard library rather than curl, which is no longer installed.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:${PORT}/health || exit 1
+    CMD python -c "import os,urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:'+os.environ['PORT']+'/health',timeout=2).status==200 else 1)"
 CMD ["./entrypoint.sh"]

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -7,8 +7,10 @@ ENV UV_PROJECT_ENVIRONMENT=/usr/local
 ENV UV_COMPILE_BYTECODE=1
 
 # uv is copied in as a static binary rather than installed with pip, so it never
-# reaches the runtime image and its advisories never apply to it.
-COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/local/bin/uv
+# reaches the runtime image and its advisories never apply to it. It is staged in
+# /usr/bin, outside the /usr/local tree the runtime stage copies from, so the
+# ~45MB binary is never baked into a runtime layer.
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/bin/uv
 
 WORKDIR /app
 
@@ -16,6 +18,17 @@ COPY ./pyproject.toml ./uv.lock /app/
 # Install exactly the locked dependency graph (main + server extra, no dev
 # group); the project itself is run from the copied source, not installed.
 RUN uv sync --locked --no-cache --no-default-groups --extra server --no-install-project
+
+# Strip packaging tooling here so the layers the runtime stage copies never
+# contain it. The runtime stage repeats the removal for the copies that ship in
+# its own base image.
+RUN python -m pip uninstall -y pip setuptools wheel 2>/dev/null || true \
+    && rm -rf /usr/local/bin/pip* /usr/local/bin/wheel \
+    /usr/local/lib/python3.14/site-packages/pip* \
+    /usr/local/lib/python3.14/site-packages/setuptools* \
+    /usr/local/lib/python3.14/site-packages/wheel* \
+    /usr/local/lib/python3.14/site-packages/_distutils_hack \
+    /usr/local/lib/python3.14/site-packages/distutils-precedence.pth
 
 # ---- runtime ----
 FROM python:3.14-slim@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6 AS runtime

--- a/presidio-anonymizer/Dockerfile.distroless
+++ b/presidio-anonymizer/Dockerfile.distroless
@@ -1,0 +1,63 @@
+# Hardened distroless variant of the presidio-anonymizer service.
+#
+# Built on Microsoft Azure Linux distroless, which ships no shell, no package
+# manager and no build tooling, so the resulting image has a far smaller
+# vulnerability surface than the Debian slim variant. See ../docs/installation.md
+# for the behavioural differences between the two variants.
+#
+# Behavioural differences vs. ./Dockerfile:
+#   * No shell, so entrypoint.sh cannot run. Gunicorn is started directly and
+#     configured through GUNICORN_CMD_ARGS instead of the PORT/WORKERS variables.
+#   * Runs on Python 3.12 (the only version Azure Linux distroless publishes),
+#     not 3.14. presidio-anonymizer supports >=3.10,<3.15.
+#   * Runs as the base image's nonroot user, UID 65532.
+
+# ---- builder: pip and build tooling exist only in this stage ----
+FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS builder
+
+# Optional alternate package index for environments without direct PyPI access.
+# Left empty by default so public builds use PyPI.
+ARG PIP_INDEX_URL
+ENV PIP_INDEX_URL=${PIP_INDEX_URL} \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /src
+
+COPY pyproject.toml ./
+COPY presidio_anonymizer ./presidio_anonymizer
+
+# .dockerignore excludes *.md, but pyproject.toml declares a readme, so the
+# build backend needs a placeholder to resolve project metadata.
+RUN printf "# presidio-anonymizer\n" > README.md \
+    && python3 -m pip install --no-cache-dir --prefix=/install ".[server]"
+
+# ---- runtime ----
+FROM mcr.microsoft.com/azurelinux/distroless/python:3.12-nonroot AS runtime
+
+# The distroless image has no shell, so gunicorn is invoked directly. Override
+# workers, bind address or any other gunicorn setting via GUNICORN_CMD_ARGS.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    GUNICORN_CMD_ARGS="--workers=1 --bind=0.0.0.0:3000"
+
+COPY --from=builder /install/lib/python3.12/site-packages /usr/lib/python3.12/site-packages
+COPY --from=builder /install/bin /usr/local/bin
+
+WORKDIR /app
+
+# The service is served from the copied source tree, which precedes
+# site-packages on sys.path. logging.ini is required: gunicorn fails to start
+# without it.
+COPY app.py logging.ini ./
+COPY presidio_anonymizer ./presidio_anonymizer
+
+USER 65532
+
+EXPOSE 3000
+
+# curl is unavailable (and would pull in a large TLS/auth dependency tree), so
+# the health check uses the Python standard library instead.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
+    CMD ["/usr/bin/python3", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://localhost:3000/health',timeout=2).status==200 else 1)"]
+
+ENTRYPOINT ["/usr/bin/python3", "-m", "gunicorn", "app:create_app()"]


### PR DESCRIPTION
## Summary

Enterprise consumers running container compliance scanning (Microsoft S360) are blocked by ~70 past-due findings against the published `presidio-analyzer` / `presidio-anonymizer` images. This addresses the S360 `RedeployMARContainerImage` and `UpdateVulnerableContainerImageReference` findings.

The change hardens the existing Debian slim images, adds a distroless variant of each service alongside them, and adds a scheduled rebuild so digest-pinned bases pick up security updates without a manual re-pin.

No application code changes. For existing image consumers the only differences are a smaller image with fewer packages.

> [!IMPORTANT]
> **One commit is not yet pushed.** The `ci: publish distroless variants and rebuild images weekly` commit touches `.github/workflows/`, and the OAuth token available in the authoring environment lacks the `workflow` scope. It is committed locally on this branch and pushes cleanly after `gh auth refresh -h github.com -s workflow`. Everything under **Publishing** below is in that commit and is *not* yet in this PR's diff.

## Vulnerabilities: before / after

Measured with `trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM`:

| Image | Total | C / H / M | Notes |
| --- | ---: | --- | --- |
| `presidio-anonymizer:latest` (before) | **262** | 3 / 100 / 159 | 240 OS + 22 language-package |
| `presidio-analyzer:latest` (before) | **281** | 6 / 110 / 165 | 261 OS + 20 language-package |
| anonymizer, hardened slim (after) | **111** | 3 / 51 / 57 | 0 language-package |
| analyzer, hardened slim (after) | **111** | 3 / 51 / 57 | 0 language-package |
| anonymizer, distroless (after) | **0** | — | fully functional |
| analyzer, distroless (after) | **0** | — | fully functional, spaCy NER verified |

Every language-package finding is eliminated in both variants. The distroless images were built for `linux/amd64` and `linux/arm64` and scanned per-platform — **both architectures report 0**.

The 3 criticals remaining in the slim variant are `perl-base` (CVE-2026-13221, CVE-2026-42496, CVE-2026-8376), all with no fix available from Debian. They cannot be resolved from this repo, which is why the distroless variant matters for consumers under compliance scanning.

## Image size: before / after

| Image | Before | After | Change |
| --- | ---: | ---: | ---: |
| anonymizer, hardened slim | 355MB | **252MB** | −29% |
| anonymizer, distroless | 355MB | **168MB** | −53% |
| analyzer, hardened slim | 1.53GB | **1.50GB** | −2% |
| analyzer, distroless | 1.53GB | **1.43GB** | −7% |

The analyzer stays large in both variants because the spaCy `en_core_web_lg` model is ~460MB on its own and is unaffected by base image choice.

## Root causes

1. **`pip install uv==0.11.6` in a single-stage build.** uv, pip and setuptools shipped in the runtime image, so build-time tooling advisories applied to a published image even though nothing at runtime uses them. This accounts for the entire language-package finding count.
2. **`apt-get install curl`, used only by the `HEALTHCHECK`.** curl drags in the whole TLS/auth stack — `libgnutls30t64`, `libkrb5-3`, `libgssapi-krb5-2`, `libk5crypto3`, `libkrb5support0`, `libssh2-1t64`, `libnghttp2-14`, `libtasn1-6`, `libldap2`, `librtmp1`, `libsasl2-2`, `libpsl5t64`, `libidn2-0`, `libbrotli1`, `libcurl4t64` — roughly a third of the findings, for one health check.
3. **Stale pinned base digests.** Debian had already fixed most of what the scanner flags (openssl, glibc, util-linux, libsystemd0, sed, libcap2, liblzma5); the images never picked it up because nothing rebuilt or re-pinned them.
4. **`cryptography` upper bound — already resolved in #2231.** The pin is `>=50.0.0,<51.0.0` and `uv.lock` resolves 50.0.1, covering CVE-2026-69249 / 69248 (fixed in 49.0.0) and CVE-2026-69247 (fixed in 50.0.0). No further pin change was needed; the encrypt/decrypt round-trip was re-verified against the rebuilt images.

## Changes

### Hardened slim images

- Converted to multi-stage builds, separating build and runtime stages. Build tooling (`pip`, `uv`, `setuptools`, `wheel`) is removed from the runtime image entirely.
- uv now ships as a static binary via `COPY --from=ghcr.io/astral-sh/uv:0.11.15`, in the **builder only**, replacing `pip install uv==0.11.6`. This is Astral's documented pattern.
- Added `apt-get upgrade -y` so published Debian security fixes are applied at build time.
- Removed `curl`; the health check uses a `python -c "import urllib.request ..."` one-liner from the standard library.
- The runtime removal of packaging tooling deliberately runs **after** every `COPY --from=builder`, because copying `/usr/local/bin` would otherwise reinstate the binaries that were just removed.
- **uv is staged in `/usr/bin`, outside the `/usr/local` tree the runtime stage copies from.** Deleting it in a runtime `RUN` removed it from the final filesystem but not from the image — the COPY layer carrying it is still shipped. The analyzer's `/usr/local/bin` layer measured 48.9MB while the directory is 148KB in the final image. Packaging tooling is now also stripped in the builder before the copy. This is what produces the size reduction above.
- Re-pinned both base digests to the current `python:3.12-slim` / `python:3.14-slim`, which are now Debian 13 (trixie).

### New distroless variants (`Dockerfile.distroless` per service)

Built on `mcr.microsoft.com/azurelinux/distroless/python:3.12-nonroot`, which ships no shell, package manager or build tooling, and runs as a non-root user. Shipped **alongside** the existing Dockerfiles rather than replacing them.

The analyzer variant builds into a venv rather than using `pip install --prefix`: `spacy download` shells out to pip, which ignores `--prefix`, so the models land in the wrong tree and the container dies at boot with `No package installer found`.

Both accept an optional `ARG PIP_INDEX_URL`, defaulting to empty so public builds use PyPI.

### Publishing (in the unpushed workflow commit)

- New reusable `.github/workflows/build-images.yml`, extracted from the existing `release.yml` build/push and manifest jobs and extended with a `variant` matrix dimension for the distroless images. `presidio-image-redactor` is excluded from the distroless variant because it depends on the Tesseract OCR system packages.
- `release.yml` now calls that reusable workflow instead of carrying its own copy, so the release path and the rebuild path cannot drift apart.
- New `.github/workflows/rebuild-images.yml`: weekly `cron` plus `workflow_dispatch`. It republishes `latest` and the current version tags on a freshly patched base, plus an immutable `<version>-<date>` tag (e.g. `2.2.364-20260909-distroless`) so a specific rebuild can be pinned or rolled back to. Scheduled rebuilds are the highest-leverage long-term change here: base images are digest-pinned, so without them a published image never picks up OS security updates.

### Docs

`docs/installation.md` and `docs/build_release.md` describe the new distroless images, their usage, the behavioural differences, an image-variant tag table, the scheduled rebuilds, and recommendations for security-conscious deployments.

## Distroless behavioural caveats

Documented in `docs/installation.md`:

- **No shell.** `entrypoint.sh` (`#!/bin/sh`) cannot run, so `PORT` and `WORKERS` are not used. Gunicorn is invoked directly and configured with `GUNICORN_CMD_ARGS`, defaulting to `--workers=1 --bind=0.0.0.0:3000`. `docker exec ... sh` is also unavailable.
- **Python 3.12.** Azure Linux distroless publishes 3.12 only. This matches the analyzer image; the **anonymizer default image runs 3.14**, so its distroless variant runs 3.12. `requires-python` is `>=3.10,<3.15`, so this is supported.
- **UID 65532** (the base image's `nonroot` user) rather than UID 1001. Adjust volume permissions or Kubernetes `runAsUser` accordingly.
- No distroless variant of `presidio-image-redactor`: it needs the Tesseract OCR system packages.

## Verification

All four images were built, run and scanned locally, and the distroless images were additionally built and verified as multi-arch manifests:

1. **Built** both distroless and both hardened slim images. Distroless also built for `linux/amd64` + `linux/arm64`.
2. **Health** — every container reaches Docker `HEALTHCHECK` status `healthy`, and `/health` responds. Confirmed on both architectures.
3. **Functional** (verified on native arm64 *and* on the amd64 images, since that is what affected consumers run)
   - Anonymizer: `POST /anonymize` with `replace` and with `encrypt`, then `POST /deanonymize` with `decrypt` — the round-trip returns the original text (`My name is James Bond`).
   - Analyzer: `POST /analyze` returns `PERSON` (0.85, so spaCy NER genuinely loaded), `EMAIL_ADDRESS`, `PHONE_NUMBER`, `CREDIT_CARD` and `URL`.
4. **Scanned** every image with trivy; counts above. Distroless scanned per-platform: 0 on amd64 and 0 on arm64 for both services.
5. **Confirmed absent** from all final images: `pip`, `pip3`, `uv`, `curl`, `wheel`, and `pip*` / `setuptools*` / `wheel*` in site-packages. The distroless images additionally have no shell.
6. **Unit tests** — anonymizer: 316 passed, 15 skipped. Analyzer: 3458 passed, 13 skipped.

Local builds used an internal package proxy because the authoring machine blocks direct PyPI access. No internal URL is committed (`ARG PIP_INDEX_URL` defaults to empty, so public CI uses public PyPI), and the built images were checked to confirm no proxy URL leaked into any package metadata.
