### PR TITLE
fix(analyzer): use the PatternRecognizer default when deny_list_score is omitted in a registry config

### DIFF
--- a/docs/analyzer/recognizer_registry_provider.md
+++ b/docs/analyzer/recognizer_registry_provider.md
@@ -109,7 +109,7 @@ The recognizer list comprises of both the predefined and custom recognizers, for
   - `enabled`: enables or disables the recognizer.
   - `supported_entity`: the detected entity associated by the recognizer.
   - `deny_list`: A list of words to detect, in case the recognizer uses a predefined list of words.
-  - `deny_list_score`: confidence score for a term identified using a deny-list.
+  - `deny_list_score`: confidence score for a term identified using a deny-list. Optional; when omitted, the `PatternRecognizer` default of `1.0` is used, the same as for recognizers created in code.
   - `score_thresholds`: optional score thresholds for this recognizer. Use `default` as the recognizer-wide threshold and entity names for overrides. Note that supplying `analyzer_engine.analyze(score_threshold=...)` bypasses recognizer-level thresholds for that request. The precedence is: Presidio Analyzer analyzer.analyze(score_threshold=...) > an entity specific threshold > a recognizer default threshold (`default`) > the Presidio Analyzer `default_score_threshold`.
   - `text_chunker`: configures how long texts are split for NER recognizers (`GLiNERRecognizer`, `HuggingFaceNerRecognizer`). Accepts a dict with `chunker_type` and params. Available types: `character` (default) and `tokenizer` (uses the model's tokenizer for accurate token-based splitting). Example:
 

--- a/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
@@ -365,7 +365,14 @@ class CustomRecognizerConfig(BaseRecognizerConfig):
         default=None, description="Words to deny/exclude"
     )
     deny_list_score: Optional[float] = Field(
-        default=0.0, ge=0.0, le=1.0, description="Deny list score"
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Score for deny-list matches. When omitted, the PatternRecognizer "
+            "default (1.0) applies, as it does for recognizers created in code "
+            "or through add_pattern_recognizer_from_dict"
+        ),
     )
 
     # Language validation (legacy and new formats)
@@ -456,6 +463,16 @@ class CustomRecognizerConfig(BaseRecognizerConfig):
                 "Custom recognizer must have at least one of 'patterns' or 'deny_list'"
             )
         return self
+
+    def model_dump(self, *args, **kwargs) -> Dict[str, Any]:
+        """Serialize the config without None values by default.
+
+        The dump is passed to ``PatternRecognizer.from_dict``. Excluding None
+        values preserves constructor defaults (for example ``deny_list_score``)
+        for omitted YAML fields instead of overriding them with explicit None.
+        """
+        kwargs.setdefault("exclude_none", True)
+        return super().model_dump(*args, **kwargs)
 
 
 class RecognizerRegistryConfig(BaseModel):

--- a/presidio-analyzer/tests/test_recognizer_registry_provider.py
+++ b/presidio-analyzer/tests/test_recognizer_registry_provider.py
@@ -8,7 +8,7 @@ from inspect import signature
 from presidio_analyzer.predefined_recognizers import SpacyRecognizer
 from presidio_analyzer.recognizer_registry import RecognizerRegistryProvider
 from presidio_analyzer.recognizer_registry.recognizers_loader_utils import RecognizerConfigurationLoader
-from presidio_analyzer import RecognizerRegistry
+from presidio_analyzer import PatternRecognizer, RecognizerRegistry
 
 
 def assert_default_configuration(
@@ -115,6 +115,69 @@ def test_recognizer_registry_provider_rejects_invalid_score_thresholds(
                 ],
             }
         )
+
+
+def _deny_list_registry_configuration(recognizer: dict) -> dict:
+    return {
+        "supported_languages": ["en"],
+        "global_regex_flags": 26,
+        "recognizers": [recognizer],
+    }
+
+
+@pytest.mark.parametrize(
+    "recognizer_conf",
+    [
+        # new-style entry: one recognizer per registry language
+        {"name": "Titles", "supported_entity": "TITLE", "deny_list": ["Mr.", "Mrs."]},
+        # legacy entry: explicit single supported_language
+        {
+            "name": "Titles",
+            "supported_language": "en",
+            "supported_entity": "TITLE",
+            "deny_list": ["Mr.", "Mrs."],
+        },
+    ],
+)
+def test_recognizer_registry_provider_omitted_deny_list_score_uses_recognizer_default(
+    recognizer_conf,
+):
+    """Omitting deny_list_score yields the PatternRecognizer default (1.0).
+
+    That is the score the recognizer gets when created in code or through
+    RecognizerRegistry.add_pattern_recognizer_from_dict.
+    """
+    provider = RecognizerRegistryProvider(
+        registry_configuration=_deny_list_registry_configuration(recognizer_conf)
+    )
+    registry = provider.create_recognizer_registry()
+    titles = next(r for r in registry.recognizers if r.name == "Titles")
+
+    in_code = PatternRecognizer(supported_entity="TITLE", deny_list=["Mr.", "Mrs."])
+    assert titles.deny_list_score == in_code.deny_list_score == 1.0
+    assert [pattern.score for pattern in titles.patterns] == [1.0]
+
+    results = titles.analyze(text="Dear Mr. Smith", entities=["TITLE"])
+    assert [(result.start, result.end, result.score) for result in results] == [
+        (5, 8, 1.0)
+    ]
+
+
+def test_recognizer_registry_provider_explicit_deny_list_score_is_honored():
+    provider = RecognizerRegistryProvider(
+        registry_configuration=_deny_list_registry_configuration(
+            {
+                "name": "Titles",
+                "supported_entity": "TITLE",
+                "deny_list": ["Mr."],
+                "deny_list_score": 0.4,
+            }
+        )
+    )
+    registry = provider.create_recognizer_registry()
+    titles = next(r for r in registry.recognizers if r.name == "Titles")
+    assert titles.deny_list_score == 0.4
+    assert [pattern.score for pattern in titles.patterns] == [0.4]
 
 
 def test_recognizer_registry_provider_configuration_file_load_predefined(mandatory_recognizers):

--- a/presidio-analyzer/tests/test_yaml_recognizer_models.py
+++ b/presidio-analyzer/tests/test_yaml_recognizer_models.py
@@ -383,6 +383,34 @@ def test_custom_recognizer_config_with_deny_list():
     assert config.deny_list_score == 0.1
 
 
+def test_custom_recognizer_config_omitted_deny_list_score_is_not_dumped():
+    """An omitted deny_list_score must not reach the PatternRecognizer as 0.0.
+
+    The dump feeds ``PatternRecognizer.from_dict``; leaving the key out lets the
+    constructor default (1.0) apply, matching recognizers created in code.
+    """
+    config = CustomRecognizerConfig(
+        name="custom_test",
+        supported_entity="CUSTOM_ENTITY",
+        deny_list=["Mr.", "Mrs."],
+    )
+    assert config.deny_list_score is None
+    dumped = config.model_dump()
+    assert "deny_list_score" not in dumped
+    assert dumped["deny_list"] == ["Mr.", "Mrs."]
+
+
+def test_custom_recognizer_config_explicit_deny_list_score_is_dumped():
+    """An explicit deny_list_score survives the dump unchanged."""
+    config = CustomRecognizerConfig(
+        name="custom_test",
+        supported_entity="CUSTOM_ENTITY",
+        deny_list=["Mr."],
+        deny_list_score=0.4,
+    )
+    assert config.model_dump()["deny_list_score"] == 0.4
+
+
 def test_custom_recognizer_config_invalid_patterns_not_list():
     """Test that patterns must be a list."""
     with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
## Change Description

A custom deny-list recognizer that omits `deny_list_score` currently gets a different score depending on how it is loaded: `PatternRecognizer(...)` and `RecognizerRegistry.add_pattern_recognizer_from_dict(...)` give the constructor default `1.0`, while `RecognizerRegistryProvider` (YAML / dict registry config) gives `0.0`, because `CustomRecognizerConfig.deny_list_score` declared `default=0.0` and that default was dumped and passed to the recognizer. A deny-list match with score `0.0` is filtered by any positive `score_threshold`, so a YAML deny list without an explicit score never fired through the provider path.

This PR:

- changes `CustomRecognizerConfig.deny_list_score` to `Optional[float] = Field(default=None, ge=0.0, le=1.0)`;
- gives `CustomRecognizerConfig` the same `model_dump(exclude_none=True)` override the other pass-through config models already have, so an omitted field is left out of the kwargs that reach `PatternRecognizer.from_dict` and the constructor default applies. Other `Optional` fields on the custom config (`patterns`, `context`, `supported_language`, `country_code`, ...) already default to `None` in the recognizer constructor, and the loader reads them with `.get(...)`, so leaving them out of the dump does not change their handling;
- documents the default in `docs/analyzer/recognizer_registry_provider.md`.

**Behavior change (existing users):** a registry config (YAML or dict) whose custom recognizer has a `deny_list` but no `deny_list_score` now yields deny-list matches with score `1.0` instead of `0.0`, i.e. those terms are now detected instead of being dropped below the threshold. Configs that set `deny_list_score` explicitly are unchanged. Detection patterns and scores of the predefined recognizers are not touched.

Tests:

- model-level: an omitted `deny_list_score` is `None` and absent from the dump; an explicit value is dumped unchanged;
- through `RecognizerRegistryProvider` (new-style entry and legacy `supported_language` entry): the constructed recognizer has `deny_list_score == 1.0`, its deny-list pattern has score `1.0`, the same as an in-code `PatternRecognizer`, and `analyze("Dear Mr. Smith")` returns the match with score `1.0`; an explicit `deny_list_score: 0.4` is honored.

Ran `uv run pytest tests/test_yaml_recognizer_models.py tests/test_recognizer_registry_provider.py` (104 passed; the two `*_chunker_config` tests fail on `main` too in an environment without the `transformers` extra) and `ruff check` / `ruff format --check` on the changed source file.

## Issue reference

Fixes #2242

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
