### PR TITLE
docs(anonymizer): drop the undefined NONE member from the ConflictResolutionStrategy docstring

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/entities/conflict_resolution_strategy.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/conflict_resolution_strategy.py
@@ -12,7 +12,6 @@ class ConflictResolutionStrategy(Enum):
     between similar or contained entities.
     REMOVE_INTERSECTIONS: Effectively resolves both intersection conflicts
     among entities and default strategy conflicts.
-    NONE: No conflict resolution will be performed.
     """
 
     MERGE_SIMILAR_OR_CONTAINED = "merge_similar_or_contained"


### PR DESCRIPTION
## Summary

Fixes #2241.

The `ConflictResolutionStrategy` docstring listed a `NONE` member ("No conflict resolution will be performed") that the enum does not define, and `AnonymizerEngine` has no opt-out path either: the merge and conflict passes in `_remove_conflicts_and_get_text_manipulation_data` always run and only `REMOVE_INTERSECTIONS` is gated. A caller following the docstring gets `AttributeError: NONE`.

## Change

Documentation only: the `NONE` line is removed from the class docstring so it describes the two members that exist. No behaviour change; adding a real no-op strategy would be a separate behaviour decision, as the issue notes.
