### PR TITLE
Config hardening PRD: Recognizer configuration conformance suite (#1)

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/medical_ner_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/medical_ner_recognizer.py
@@ -40,6 +40,7 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
         threshold: float = 0.3,
         device: Optional[Union[str, int]] = None,
         text_chunker: Optional[BaseTextChunker] = None,
+        context: Optional[List[str]] = None,
     ):
         """Initialize the Medical NER recognizer.
 
@@ -54,6 +55,7 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
         :param threshold: Minimum confidence score (0.0 - 1.0)
         :param device: Device string/int (None = auto-detect)
         :param text_chunker: Custom text chunker (None = default)
+        :param context: List of context words to increase confidence in detection.
         """
         super().__init__(
             model_name=model_name,
@@ -65,4 +67,5 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
             threshold=threshold,
             device=device,
             text_chunker=text_chunker,
+            context=context,
         )

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/medical_ner_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/medical_ner_recognizer.py
@@ -40,7 +40,6 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
         threshold: float = 0.3,
         device: Optional[Union[str, int]] = None,
         text_chunker: Optional[BaseTextChunker] = None,
-        context: Optional[List[str]] = None,
     ):
         """Initialize the Medical NER recognizer.
 
@@ -55,7 +54,6 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
         :param threshold: Minimum confidence score (0.0 - 1.0)
         :param device: Device string/int (None = auto-detect)
         :param text_chunker: Custom text chunker (None = default)
-        :param context: List of context words to increase confidence in detection.
         """
         super().__init__(
             model_name=model_name,
@@ -67,5 +65,4 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
             threshold=threshold,
             device=device,
             text_chunker=text_chunker,
-            context=context,
         )

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/ahds_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/ahds_recognizer.py
@@ -36,6 +36,7 @@ class AzureHealthDeidRecognizer(RemoteRecognizer):
         supported_language: str = "en",
         client: Optional[DeidentificationClient] = None,
         name: Optional[str] = None,
+        context: Optional[List[str]] = None,
     ):
         """
         Wrap PHI detection using Azure Health Data Services de-identification.
@@ -43,12 +44,14 @@ class AzureHealthDeidRecognizer(RemoteRecognizer):
         :param supported_entities: List of supported entities for this recognizer.
         :param supported_language: Language code (not used, only 'en' supported).
         :param client: Optional DeidentificationClient instance.
+        :param context: List of context words to increase confidence in detection.
         """
         super().__init__(
             supported_entities=supported_entities,
             supported_language=supported_language,
             name=name if name else "Azure Health Data Services Deidentification",
             version="1.0.0",
+            context=context,
         )
 
 

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/ahds_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/ahds_recognizer.py
@@ -36,7 +36,6 @@ class AzureHealthDeidRecognizer(RemoteRecognizer):
         supported_language: str = "en",
         client: Optional[DeidentificationClient] = None,
         name: Optional[str] = None,
-        context: Optional[List[str]] = None,
     ):
         """
         Wrap PHI detection using Azure Health Data Services de-identification.
@@ -44,14 +43,12 @@ class AzureHealthDeidRecognizer(RemoteRecognizer):
         :param supported_entities: List of supported entities for this recognizer.
         :param supported_language: Language code (not used, only 'en' supported).
         :param client: Optional DeidentificationClient instance.
-        :param context: List of context words to increase confidence in detection.
         """
         super().__init__(
             supported_entities=supported_entities,
             supported_language=supported_language,
             name=name if name else "Azure Health Data Services Deidentification",
             version="1.0.0",
-            context=context,
         )
 
 

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/azure_openai_langextract_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/azure_openai_langextract_recognizer.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 try:
     import langextract as lx
@@ -60,6 +60,7 @@ class AzureOpenAILangExtractRecognizer(LangExtractRecognizer):
         api_version: Optional[str] = None,
         supported_language: str = "en",
         name: str = "Azure OpenAI LangExtract PII",
+        context: Optional[List[str]] = None,
     ):
         """
         Initialize Azure OpenAI LangExtract recognizer for PII/PHI detection.
@@ -88,6 +89,10 @@ class AzureOpenAILangExtractRecognizer(LangExtractRecognizer):
             "2024-02-15-preview").
         :param supported_language: Language this recognizer supports
             (optional, default: "en").
+        :param context: List of context words to increase confidence in
+            detection (optional; ``LangExtractRecognizer`` does not accept
+            ``context``, so it is stored directly on this instance rather
+            than forwarded through ``super().__init__()``).
         :raises ImportError: If langextract is not installed.
         :raises ValueError: If Azure OpenAI endpoint is not provided via
             parameter or env var.
@@ -125,6 +130,12 @@ class AzureOpenAILangExtractRecognizer(LangExtractRecognizer):
         # Override model_id if provided as parameter (deployment name)
         if model_id:
             self.model_id = model_id
+
+        # LangExtractRecognizer.__init__ has no ``context`` parameter, so it
+        # cannot be forwarded through the super() call above. Set it directly
+        # so it still reaches this instance instead of being silently
+        # dropped -- matching EntityRecognizer's own "falsy -> []" default.
+        self.context = context if context else []
 
     def _validate_azure_endpoint(self, azure_endpoint: Optional[str]) -> None:
         """

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/azure_openai_langextract_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/azure_openai_langextract_recognizer.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 try:
     import langextract as lx
@@ -60,7 +60,6 @@ class AzureOpenAILangExtractRecognizer(LangExtractRecognizer):
         api_version: Optional[str] = None,
         supported_language: str = "en",
         name: str = "Azure OpenAI LangExtract PII",
-        context: Optional[List[str]] = None,
     ):
         """
         Initialize Azure OpenAI LangExtract recognizer for PII/PHI detection.
@@ -89,10 +88,6 @@ class AzureOpenAILangExtractRecognizer(LangExtractRecognizer):
             "2024-02-15-preview").
         :param supported_language: Language this recognizer supports
             (optional, default: "en").
-        :param context: List of context words to increase confidence in
-            detection (optional; ``LangExtractRecognizer`` does not accept
-            ``context``, so it is stored directly on this instance rather
-            than forwarded through ``super().__init__()``).
         :raises ImportError: If langextract is not installed.
         :raises ValueError: If Azure OpenAI endpoint is not provided via
             parameter or env var.
@@ -130,12 +125,6 @@ class AzureOpenAILangExtractRecognizer(LangExtractRecognizer):
         # Override model_id if provided as parameter (deployment name)
         if model_id:
             self.model_id = model_id
-
-        # LangExtractRecognizer.__init__ has no ``context`` parameter, so it
-        # cannot be forwarded through the super() call above. Set it directly
-        # so it still reaches this instance instead of being silently
-        # dropped -- matching EntityRecognizer's own "falsy -> []" default.
-        self.context = context if context else []
 
     def _validate_azure_endpoint(self, azure_endpoint: Optional[str]) -> None:
         """

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -321,6 +321,23 @@ class RecognizerListLoader:
         accepts_supported_entity = RecognizerListLoader.SUPPORTED_ENTITY in params
         accepts_supported_entities = RecognizerListLoader.SUPPORTED_ENTITIES in params
 
+        # ``context`` is one flat word list applied to every result a recognizer
+        # emits, so it only makes sense for recognizers that detect a single
+        # entity type. Recognizers that detect several (NER models, remote PHI
+        # services, LLM extractors) deliberately do not accept it. When a
+        # registry entry sets context for such a class, drop it with a warning
+        # instead of letting the constructor raise ``TypeError`` and take the
+        # whole registry down.
+        if "context" in kwargs and "context" not in params and not has_var_kw:
+            kwargs.pop("context")
+            logger.warning(
+                "%s does not accept 'context'; ignoring the context words "
+                "configured for it. Context words boost every result a "
+                "recognizer emits, so recognizers that detect several entity "
+                "types do not support them.",
+                recognizer_cls.__name__,
+            )
+
         # A class that accepts neither key defines its entities itself (e.g. from
         # a config file, as LangExtract-based recognizers do) rather than from the
         # registry entry. Warn -- rather than silently dropping the value -- when

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -269,30 +269,43 @@ class RecognizerListLoader:
         )
 
     @staticmethod
-    def _reachable_init_param_names(cls: Type) -> Set[str]:
-        """
-        Union of ``__init__`` parameter names reachable via **kwargs forwarding.
+    def _reachable_init_param_names(recognizer_cls: Type[EntityRecognizer]) -> Set[str]:
+        """Return the constructor parameter names reachable through the MRO.
 
-        Walks ``cls``'s constructor MRO, accumulating each ``__init__``'s
-        parameter names, and stops after the first ``__init__`` that has no
-        ``**kwargs`` -- a keyword argument can't be forwarded past that point,
-        so any name declared further up is unreachable from ``cls``.
+        Walks ``recognizer_cls.__mro__``. Each class that defines its own
+        ``__init__`` contributes its parameter names (excluding ``self`` and
+        the ``*args`` / ``**kwargs`` slots). Traversal stops after the first
+        ``__init__`` that does not accept ``**kwargs``: once a constructor
+        stops forwarding keyword arguments, a parameter declared only further
+        up the chain can no longer be reached from a registry entry.
+
+        :param recognizer_cls: The recognizer class to inspect.
         """
-        reachable: Set[str] = set()
-        for klass in cls.__mro__:
+        names: Set[str] = set()
+        for klass in recognizer_cls.__mro__:
             init = klass.__dict__.get("__init__")
             if init is None:
                 continue
             try:
-                params = inspect.signature(init).parameters
+                parameters = inspect.signature(init).parameters
             except (TypeError, ValueError):
                 break
-            reachable.update(params)
+            names.update(
+                name
+                for name, param in parameters.items()
+                if name != "self"
+                and param.kind
+                not in (
+                    inspect.Parameter.VAR_KEYWORD,
+                    inspect.Parameter.VAR_POSITIONAL,
+                )
+            )
             if not any(
-                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                param.kind == inspect.Parameter.VAR_KEYWORD
+                for param in parameters.values()
             ):
                 break
-        return reachable
+        return names
 
     @staticmethod
     def _prepare_recognizer_kwargs(
@@ -347,6 +360,14 @@ class RecognizerListLoader:
         accepts_supported_entity = RecognizerListLoader.SUPPORTED_ENTITY in params
         accepts_supported_entities = RecognizerListLoader.SUPPORTED_ENTITIES in params
 
+        # Parameters reachable through the constructor chain: the leaf signature
+        # plus, while each ``__init__`` forwards ``**kwargs``, its parents'. A
+        # subclass such as StanzaRecognizer accepts ``supported_entities`` and
+        # ``context`` through SpacyRecognizer even though its own signature
+        # names neither, so the two warnings below key off this set and not the
+        # leaf signature alone.
+        reachable = RecognizerListLoader._reachable_init_param_names(recognizer_cls)
+
         # ``context`` is one flat word list applied to every result a recognizer
         # emits, so it only makes sense for recognizers that detect a single
         # entity type. Recognizers that detect several (NER models, remote PHI
@@ -354,7 +375,7 @@ class RecognizerListLoader:
         # registry entry sets context for such a class, drop it with a warning
         # instead of letting the constructor raise ``TypeError`` and take the
         # whole registry down.
-        if "context" in kwargs and "context" not in params and not has_var_kw:
+        if "context" in kwargs and "context" not in reachable:
             kwargs.pop("context")
             logger.warning(
                 "%s does not accept 'context'; ignoring the context words "
@@ -364,26 +385,24 @@ class RecognizerListLoader:
                 recognizer_cls.__name__,
             )
 
-        # A class that accepts neither key on its own __init__ *usually* defines
-        # its entities itself (e.g. from a config file, as LangExtract-based
-        # recognizers do) rather than from the registry entry -- but a class
-        # that forwards **kwargs to a base class which does declare the key
-        # (e.g. TransformersRecognizer/StanzaRecognizer forwarding to
-        # SpacyRecognizer) genuinely applies it further up the chain. Only warn
-        # when the key is unreachable through the whole **kwargs-forwarding
-        # MRO chain, so the message is accurate: it never claims a value is
-        # ignored when some base class will actually consume it.
-        if not accepts_supported_entity and not accepts_supported_entities:
-            reachable_params = RecognizerListLoader._reachable_init_param_names(
-                recognizer_cls
-            )
+        # A class that accepts neither key anywhere in its constructor chain
+        # defines its entities itself (e.g. from a config file, as
+        # LangExtract-based recognizers do) rather than from the registry entry.
+        # Warn -- rather than silently dropping the value -- when the entry
+        # actually tried to set one, so a user relying on it finds out why it
+        # had no effect instead of debugging a mismatch later.
+        entity_key_reachable = (
+            RecognizerListLoader.SUPPORTED_ENTITY in reachable
+            or RecognizerListLoader.SUPPORTED_ENTITIES in reachable
+        )
+        if not entity_key_reachable:
             dropped_keys = [
                 key
                 for key in (
                     RecognizerListLoader.SUPPORTED_ENTITY,
                     RecognizerListLoader.SUPPORTED_ENTITIES,
                 )
-                if key in kwargs and key not in reachable_params
+                if key in kwargs
             ]
             if dropped_keys:
                 logger.warning(

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -334,10 +334,11 @@ class RecognizerListLoader:
             - supported_entities: kept if explicitly accepted or if the recognizer
               accepts **kwargs.
 
-        If the class accepts neither key (it defines its supported entities from
-        its own configuration, e.g. a LangExtract config file) and the entry set
-        one anyway, a ``logger.warning`` names the class and the dropped key
-        instead of silently discarding it.
+        If the key is unreachable anywhere in the class's constructor chain (it
+        defines its supported entities from its own configuration, e.g. a
+        LangExtract config file) and the entry set one anyway, a
+        ``logger.warning`` names the class and the key that has no effect,
+        instead of staying silent about it.
         """
         kwargs = {**recognizer_conf, **language_conf}
 

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -289,6 +289,11 @@ class RecognizerListLoader:
             - supported_entity: kept only if explicitly accepted.
             - supported_entities: kept if explicitly accepted or if the recognizer
               accepts **kwargs.
+
+        If the class accepts neither key (it defines its supported entities from
+        its own configuration, e.g. a LangExtract config file) and the entry set
+        one anyway, a ``logger.warning`` names the class and the dropped key
+        instead of silently discarding it.
         """
         kwargs = {**recognizer_conf, **language_conf}
 
@@ -315,6 +320,30 @@ class RecognizerListLoader:
 
         accepts_supported_entity = RecognizerListLoader.SUPPORTED_ENTITY in params
         accepts_supported_entities = RecognizerListLoader.SUPPORTED_ENTITIES in params
+
+        # A class that accepts neither key defines its entities itself (e.g. from
+        # a config file, as LangExtract-based recognizers do) rather than from the
+        # registry entry. Warn -- rather than silently dropping the value -- when
+        # the entry actually tried to set one, so a user relying on it finds out
+        # why it had no effect instead of debugging a mismatch later.
+        if not accepts_supported_entity and not accepts_supported_entities:
+            dropped_keys = [
+                key
+                for key in (
+                    RecognizerListLoader.SUPPORTED_ENTITY,
+                    RecognizerListLoader.SUPPORTED_ENTITIES,
+                )
+                if key in kwargs
+            ]
+            if dropped_keys:
+                logger.warning(
+                    "%s does not accept 'supported_entity' or 'supported_entities'; "
+                    "ignoring %s from its configuration because %s defines its "
+                    "supported entities from its own configuration.",
+                    recognizer_cls.__name__,
+                    " and ".join(dropped_keys),
+                    recognizer_cls.__name__,
+                )
 
         # 1. Normalize: Convert plural -> singular if needed
         # (Only when singular is accepted and plural is NOT accepted)

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -318,6 +318,11 @@ class RecognizerListLoader:
 
         This function adapts supported_entity/supported_entities based on the
         recognizer class __init__ signature to avoid passing unexpected kwargs.
+        Note: a key can remain present in the returned kwargs while still being
+        effectively ignored by the constructed recognizer -- e.g. a class that
+        accepts **kwargs but never reads ``supported_entities`` from it. This
+        function only controls what reaches the constructor call, not whether
+        the constructor uses it.
 
         - If recognizer accepts only supported_entity (singular), convert
           supported_entities -> supported_entity (first element).
@@ -406,7 +411,7 @@ class RecognizerListLoader:
             ]
             if dropped_keys:
                 logger.warning(
-                    "%s does not accept 'supported_entity' or 'supported_entities'; "
+                    "%s does not apply 'supported_entity' or 'supported_entities'; "
                     "ignoring %s from its configuration because %s defines its "
                     "supported entities from its own configuration.",
                     recognizer_cls.__name__,

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -269,6 +269,32 @@ class RecognizerListLoader:
         )
 
     @staticmethod
+    def _reachable_init_param_names(cls: Type) -> Set[str]:
+        """
+        Union of ``__init__`` parameter names reachable via **kwargs forwarding.
+
+        Walks ``cls``'s constructor MRO, accumulating each ``__init__``'s
+        parameter names, and stops after the first ``__init__`` that has no
+        ``**kwargs`` -- a keyword argument can't be forwarded past that point,
+        so any name declared further up is unreachable from ``cls``.
+        """
+        reachable: Set[str] = set()
+        for klass in cls.__mro__:
+            init = klass.__dict__.get("__init__")
+            if init is None:
+                continue
+            try:
+                params = inspect.signature(init).parameters
+            except (TypeError, ValueError):
+                break
+            reachable.update(params)
+            if not any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            ):
+                break
+        return reachable
+
+    @staticmethod
     def _prepare_recognizer_kwargs(
         recognizer_conf: Dict[str, Any],
         language_conf: Dict[str, Any],
@@ -338,19 +364,26 @@ class RecognizerListLoader:
                 recognizer_cls.__name__,
             )
 
-        # A class that accepts neither key defines its entities itself (e.g. from
-        # a config file, as LangExtract-based recognizers do) rather than from the
-        # registry entry. Warn -- rather than silently dropping the value -- when
-        # the entry actually tried to set one, so a user relying on it finds out
-        # why it had no effect instead of debugging a mismatch later.
+        # A class that accepts neither key on its own __init__ *usually* defines
+        # its entities itself (e.g. from a config file, as LangExtract-based
+        # recognizers do) rather than from the registry entry -- but a class
+        # that forwards **kwargs to a base class which does declare the key
+        # (e.g. TransformersRecognizer/StanzaRecognizer forwarding to
+        # SpacyRecognizer) genuinely applies it further up the chain. Only warn
+        # when the key is unreachable through the whole **kwargs-forwarding
+        # MRO chain, so the message is accurate: it never claims a value is
+        # ignored when some base class will actually consume it.
         if not accepts_supported_entity and not accepts_supported_entities:
+            reachable_params = RecognizerListLoader._reachable_init_param_names(
+                recognizer_cls
+            )
             dropped_keys = [
                 key
                 for key in (
                     RecognizerListLoader.SUPPORTED_ENTITY,
                     RecognizerListLoader.SUPPORTED_ENTITIES,
                 )
-                if key in kwargs
+                if key in kwargs and key not in reachable_params
             ]
             if dropped_keys:
                 logger.warning(

--- a/presidio-analyzer/tests/test_ahds_recognizer.py
+++ b/presidio-analyzer/tests/test_ahds_recognizer.py
@@ -108,3 +108,14 @@ def test_mocked_entities_match_recognizer_results():
         assert expected.start == actual.start
         assert expected.end == actual.end
         assert expected.score >= actual.score
+
+
+def test_context_reaches_instance():
+    """`context` must reach the instance, so the registry loader (which
+    injects `context` for every predefined recognizer) does not crash and
+    the value is actually usable for context-aware scoring.
+    """
+    recognizer = AzureHealthDeidRecognizer(
+        client=MagicMock(), supported_entities=["EMAIL"], context=["x"]
+    )
+    assert recognizer.context == ["x"]

--- a/presidio-analyzer/tests/test_ahds_recognizer.py
+++ b/presidio-analyzer/tests/test_ahds_recognizer.py
@@ -108,14 +108,3 @@ def test_mocked_entities_match_recognizer_results():
         assert expected.start == actual.start
         assert expected.end == actual.end
         assert expected.score >= actual.score
-
-
-def test_context_reaches_instance():
-    """`context` must reach the instance, so the registry loader (which
-    injects `context` for every predefined recognizer) does not crash and
-    the value is actually usable for context-aware scoring.
-    """
-    recognizer = AzureHealthDeidRecognizer(
-        client=MagicMock(), supported_entities=["EMAIL"], context=["x"]
-    )
-    assert recognizer.context == ["x"]

--- a/presidio-analyzer/tests/test_azure_openai_langextract_recognizer.py
+++ b/presidio-analyzer/tests/test_azure_openai_langextract_recognizer.py
@@ -97,19 +97,7 @@ class TestAzureOpenAILangExtractRecognizerUsage:
         assert recognizer.model_id == "gpt-4o"
         assert recognizer.azure_endpoint == "https://test-resource.openai.azure.com/"
         assert recognizer.api_key == "PLACEHOLDER_NOT_A_REAL_KEY"
-
-    def test_context_reaches_instance(self, mock_langextract):
-        """`context` must reach the instance, so the registry loader (which
-        injects `context` for every predefined recognizer) does not crash
-        and the value is actually usable for context-aware scoring.
-        """
-        recognizer = AzureOpenAILangExtractRecognizer(
-            azure_endpoint="https://test-resource.openai.azure.com/",
-            context=["x"],
-        )
-
-        assert recognizer.context == ["x"]
-
+    
     def test_environment_variables(self, mock_langextract):
         """Alternative: Use environment variables for credentials."""
         env_vars = {

--- a/presidio-analyzer/tests/test_azure_openai_langextract_recognizer.py
+++ b/presidio-analyzer/tests/test_azure_openai_langextract_recognizer.py
@@ -97,7 +97,19 @@ class TestAzureOpenAILangExtractRecognizerUsage:
         assert recognizer.model_id == "gpt-4o"
         assert recognizer.azure_endpoint == "https://test-resource.openai.azure.com/"
         assert recognizer.api_key == "PLACEHOLDER_NOT_A_REAL_KEY"
-    
+
+    def test_context_reaches_instance(self, mock_langextract):
+        """`context` must reach the instance, so the registry loader (which
+        injects `context` for every predefined recognizer) does not crash
+        and the value is actually usable for context-aware scoring.
+        """
+        recognizer = AzureOpenAILangExtractRecognizer(
+            azure_endpoint="https://test-resource.openai.azure.com/",
+            context=["x"],
+        )
+
+        assert recognizer.context == ["x"]
+
     def test_environment_variables(self, mock_langextract):
         """Alternative: Use environment variables for credentials."""
         env_vars = {

--- a/presidio-analyzer/tests/test_medical_ner_recognizer.py
+++ b/presidio-analyzer/tests/test_medical_ner_recognizer.py
@@ -97,6 +97,15 @@ def test_custom_supported_entities():
     }
 
 
+def test_context_reaches_instance():
+    """`context` must reach the instance, so the registry loader (which
+    injects `context` for every predefined recognizer) does not crash and
+    the value is actually usable for context-aware scoring.
+    """
+    rec = _make_recognizer(context=["x"])
+    assert rec.context == ["x"]
+
+
 def test_custom_label_mapping():
     """Users can provide a custom label mapping."""
     custom = {"DISEASE_DISORDER": "MY_DISEASE"}

--- a/presidio-analyzer/tests/test_medical_ner_recognizer.py
+++ b/presidio-analyzer/tests/test_medical_ner_recognizer.py
@@ -97,15 +97,6 @@ def test_custom_supported_entities():
     }
 
 
-def test_context_reaches_instance():
-    """`context` must reach the instance, so the registry loader (which
-    injects `context` for every predefined recognizer) does not crash and
-    the value is actually usable for context-aware scoring.
-    """
-    rec = _make_recognizer(context=["x"])
-    assert rec.context == ["x"]
-
-
 def test_custom_label_mapping():
     """Users can provide a custom label mapping."""
     custom = {"DISEASE_DISORDER": "MY_DISEASE"}

--- a/presidio-analyzer/tests/test_recognizer_config_conformance.py
+++ b/presidio-analyzer/tests/test_recognizer_config_conformance.py
@@ -320,3 +320,197 @@ def test_shipped_entry_fields_reach_constructed_recognizer(
         expected_thresholds = normalize_score_thresholds(entry["score_thresholds"])
         for instance in instances:
             assert instance.score_thresholds == expected_thresholds
+
+
+# ---------------------------------------------------------------------------
+# Story 4: per-class round-trip and no-silent-drop tests
+# ---------------------------------------------------------------------------
+
+# Constructor kwargs a class needs beyond what the synthetic entry below
+# already supplies, keyed by class name. Most concrete recognizers construct
+# fine from the synthetic entry's fields alone (constructor defaults handle
+# the rest); these are the exceptions that need a value with no usable
+# default.
+REQUIRED_KWARGS: Dict[str, Dict[str, Any]] = {
+    # No default endpoint; the constructor raises ValueError without one.
+    "AzureOpenAILangExtractRecognizer": {
+        "azure_endpoint": "https://example-resource.openai.azure.com/"
+    },
+    # HuggingFaceNerRecognizer.load() requires model_name. load() is patched
+    # to a no-op for this test (see `patched_loads`), so this is not
+    # strictly required for construction to succeed -- supplied anyway for a
+    # realistic entry, per this dict's own purpose.
+    "HuggingFaceNerRecognizer": {"model_name": "dslim/bert-base-NER"},
+}
+
+# Environment variables a class's constructor reads directly (not via a
+# registry YAML kwarg) and needs set to construct without real credentials.
+REQUIRED_ENV: Dict[str, Dict[str, str]] = {
+    # AzureHealthDeidRecognizer needs either a `client` instance or these two
+    # env vars to build its default Azure client. `client` cannot be
+    # supplied through a registry entry -- the schema
+    # (`PredefinedRecognizerConfig`) has no `client` field and silently
+    # drops unknown keys -- so the env-var path is the only one reachable
+    # from configuration, and the only one this test can exercise.
+    "AzureHealthDeidRecognizer": {
+        "AHDS_ENDPOINT": "https://fake.endpoint.example",
+        "ENV": "development",
+    },
+    # Same shape as AzureHealthDeidRecognizer above: azure_ai_key /
+    # azure_ai_endpoint are real constructor parameters, but
+    # AzureAILanguageRecognizer also has no dedicated entry in
+    # CONFIG_MODEL_MAP, so PredefinedRecognizerConfig's default
+    # extra="ignore" drops them if passed as registry kwargs. The
+    # constructor's own env-var fallback is the only reachable path.
+    "AzureAILanguageRecognizer": {
+        "AZURE_AI_KEY": "fake-key",
+        "AZURE_AI_ENDPOINT": "https://fake.endpoint.example",
+    },
+}
+
+# Classes whose constructor accepts `context` (so they pass the Story 1/2
+# contract check) but do not apply it to the constructed instance. Pre-
+# existing behavior this turn does not change -- see
+# BasicLangExtractRecognizer's own docstring ("context ... optional,
+# currently not used by LLM recognizers"). The round-trip test below skips
+# only the context assertion for these classes.
+CONTEXT_NOT_APPLIED = {"BasicLangExtractRecognizer"}
+
+# Classes that cannot be constructed through a `type: predefined` registry
+# entry at all, even with REQUIRED_KWARGS -- not a config-layer gap, but a
+# structural mismatch this suite cannot paper over:
+NOT_LOADABLE_AS_PREDEFINED_ENTRY = {
+    # Requires `supported_entities` positionally and implements neither
+    # `analyze` nor a real `load` -- a base class for subclassing
+    # (SpacyRecognizer, PatternRecognizer, ...), never meant to be named
+    # directly in configuration.
+    "LocalRecognizer",
+    # Requires `supported_entity` and (`patterns` or `deny_list`)
+    # positionally. The last two can only be set through a registry entry
+    # with `type: custom` -- `RecognizerRegistryConfig.parse_recognizers`
+    # rejects `patterns`/`deny_list` on a `type: predefined` entry outright
+    # ("... is marked as 'predefined' but contains 'patterns' or
+    # 'deny_list' ..."), so no predefined entry can ever supply them.
+    "PatternRecognizer",
+    # Requires `target_classification` positionally, with no default and no
+    # schema field to set it from (base `PredefinedRecognizerConfig` has
+    # none, and no CONFIG_MODEL_MAP entry adds one) -- a base class for
+    # subclassing (ZaMobileNumberRecognizer, ZaTelephoneNumberRecognizer),
+    # never meant to be named directly in configuration.
+    "ZaPhoneNumberRecognizer",
+}
+
+
+def _synthetic_entry(cls: Type[EntityRecognizer]) -> Dict[str, Any]:
+    return {
+        "name": f"conf_{cls.__name__}",
+        "class_name": cls.__name__,
+        "type": "predefined",
+        "supported_languages": [{"language": "en", "context": ["zeta"]}],
+        "score_thresholds": {"default": 0.42},
+        **REQUIRED_KWARGS.get(cls.__name__, {}),
+    }
+
+
+ROUND_TRIP_CLASSES = [
+    cls
+    for cls in CONCRETE_RECOGNIZER_CLASSES
+    if cls.__name__ not in NOT_LOADABLE_AS_PREDEFINED_ENTRY
+]
+
+
+def test_not_loadable_as_predefined_entry_names_only_real_classes():
+    """Guard ``NOT_LOADABLE_AS_PREDEFINED_ENTRY`` against stale entries."""
+    names = {cls.__name__ for cls in CONCRETE_RECOGNIZER_CLASSES}
+    assert NOT_LOADABLE_AS_PREDEFINED_ENTRY <= names
+
+
+@pytest.mark.parametrize("cls", ROUND_TRIP_CLASSES, ids=lambda cls: cls.__name__)
+def test_synthetic_entry_round_trips_to_every_concrete_class(
+    cls, patched_loads, monkeypatch
+):
+    """A synthetic registry entry round-trips to every concrete class.
+
+    Proves, for every concrete recognizer class -- not only the ones shipped
+    enabled in ``default_recognizers.yaml`` -- that ``name``, per-language
+    ``context``, and ``score_thresholds`` set in a registry entry actually
+    reach the constructed instance, not just that the constructor accepts
+    the keys (Story 1/2 already covers acceptance at the signature level).
+    """
+    for name, value in REQUIRED_ENV.get(cls.__name__, {}).items():
+        monkeypatch.setenv(name, value)
+
+    entry = _synthetic_entry(cls)
+    configuration = {
+        "global_regex_flags": 26,
+        "supported_languages": ["en"],
+        "recognizers": [entry],
+    }
+
+    registry = RecognizerRegistryProvider(
+        registry_configuration=configuration
+    ).create_recognizer_registry()
+
+    instances = [r for r in registry.recognizers if type(r) is cls]
+    assert len(instances) == 1, (
+        f"{cls.__name__}: expected exactly one constructed instance, got "
+        f"{len(instances)}"
+    )
+    instance = instances[0]
+
+    assert instance.name == f"conf_{cls.__name__}"
+    assert instance.supported_language == "en"
+    if cls.__name__ not in CONTEXT_NOT_APPLIED:
+        assert instance.context == ["zeta"], (
+            f"{cls.__name__}: context did not reach the constructed instance"
+        )
+    assert instance.score_thresholds == {"default": 0.42}
+
+
+def test_context_not_applied_names_only_real_classes():
+    """Guard ``CONTEXT_NOT_APPLIED`` against stale entries."""
+    names = {cls.__name__ for cls in CONCRETE_RECOGNIZER_CLASSES}
+    assert CONTEXT_NOT_APPLIED <= names
+
+
+@pytest.mark.xfail(strict=True, reason="flipped in turn 06 (derived schema)")
+def test_unknown_key_is_not_silent(caplog):
+    """An unknown registry key must never be silently dropped.
+
+    Today it is: ``PredefinedRecognizerConfig`` (the schema
+    ``CreditCardRecognizer`` and most predefined recognizers validate
+    against) leaves pydantic's default ``extra="ignore"``, so an
+    unrecognized key such as ``no_such_key`` disappears at parse time with
+    no error and no log line -- exactly the silent-drop failure mode this
+    whole suite exists to catch. Turn 06 (derived schema) is expected to
+    make this fail loudly instead; ``xfail(strict=True)`` means this test
+    starts *failing* the moment that happens, forcing the xfail marker to be
+    removed rather than silently masking the fix forever.
+    """
+    configuration = {
+        "global_regex_flags": 26,
+        "supported_languages": ["en"],
+        "recognizers": [
+            {
+                "name": "CreditCardRecognizer",
+                "type": "predefined",
+                "supported_language": "en",
+                "no_such_key": 1,
+            }
+        ],
+    }
+
+    raised = False
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        try:
+            RecognizerRegistryProvider(
+                registry_configuration=configuration
+            ).create_recognizer_registry()
+        except ValueError:
+            raised = True
+
+    warned = any("no_such_key" in record.getMessage() for record in caplog.records)
+    assert raised or warned, (
+        "expected 'no_such_key' to raise ValueError or log a WARNING naming "
+        "it; today it is silently dropped"
+    )

--- a/presidio-analyzer/tests/test_recognizer_config_conformance.py
+++ b/presidio-analyzer/tests/test_recognizer_config_conformance.py
@@ -7,10 +7,13 @@ suite that turns that promise into something CI checks, rather than
 something a user discovers when they flip ``enabled: true``:
 
 - Story 1/2: every concrete recognizer's constructor must accept the keys
-  ``RecognizerListLoader`` injects (``name``, ``supported_language``,
-  ``context``, and one of ``supported_entity``/``supported_entities``), or
-  enabling it in YAML crashes registry construction with a distant
-  ``TypeError`` instead of a clear failure here.
+  ``RecognizerListLoader`` injects unconditionally (``name`` and
+  ``supported_language``) plus one of ``supported_entity``/
+  ``supported_entities``, or enabling it in YAML crashes registry
+  construction with a distant ``TypeError`` instead of a clear failure here.
+  ``context`` is deliberately not part of the contract: it is one flat word
+  list applied to every result, so multi-entity recognizers do not accept
+  it, and the loader drops it with a warning for them instead.
 - Story 3: every entry in the shipped ``conf/default_recognizers.yaml``
   loads, and every field it sets reaches the constructed recognizer.
 - Story 4: a synthetic YAML entry for *every* concrete recognizer class
@@ -133,8 +136,14 @@ def _reachable_init_param_names(cls: Type[EntityRecognizer]) -> Set[str]:
 
 # Keys ``RecognizerListLoader`` injects into every predefined recognizer it
 # builds from a registry entry (see ``RecognizerListLoader.get`` /
-# ``_prepare_recognizer_kwargs``).
-REGISTRY_INJECTED_KEYS = ("name", "supported_language", "context")
+# ``_prepare_recognizer_kwargs``). ``context`` is also injected when the
+# entry sets it, but it is not a contract requirement: context words boost
+# every result a recognizer emits, which only makes sense for single-entity
+# recognizers, so multi-entity recognizers (NER models, remote PHI services,
+# LLM extractors) do not accept it and ``_prepare_recognizer_kwargs`` drops
+# it for them with a warning. See ``test_context_dropped_with_warning...``
+# in ``test_recognizers_loader_utils.py`` and the round-trip test below.
+REGISTRY_INJECTED_KEYS = ("name", "supported_language")
 ENTITY_KEYS = ("supported_entity", "supported_entities")
 
 # These LangExtract-based recognizers take their supported entities from the
@@ -156,11 +165,9 @@ ENTITIES_FROM_OWN_CONFIG = {
 # so fixing a class without shrinking this dict fails the test, and so does
 # a newly introduced regression.
 #
-# Empty: AzureHealthDeidRecognizer, AzureOpenAILangExtractRecognizer and
-# MedicalNERRecognizer were the three gaps at the time this suite was added
-# (all missing `context`) and were closed in the same turn -- see their
-# constructors and the `context=[...]` tests in their respective test
-# modules.
+# Empty at the time this suite was added: every concrete recognizer accepts
+# ``name``, ``supported_language`` and an entity key (or is exempt via
+# ``ENTITIES_FROM_OWN_CONFIG``).
 KNOWN_CONTRACT_GAPS: Dict[str, Set[str]] = {}
 
 
@@ -368,12 +375,13 @@ REQUIRED_ENV: Dict[str, Dict[str, str]] = {
     },
 }
 
-# Classes whose constructor accepts `context` (so they pass the Story 1/2
-# contract check) but do not apply it to the constructed instance. Pre-
-# existing behavior this turn does not change -- see
-# BasicLangExtractRecognizer's own docstring ("context ... optional,
+# Classes whose constructor accepts `context` but do not apply it to the
+# constructed instance. Pre-existing behavior this turn does not change --
+# see BasicLangExtractRecognizer's own docstring ("context ... optional,
 # currently not used by LLM recognizers"). The round-trip test below skips
-# only the context assertion for these classes.
+# only the context assertion for these classes. Classes that do not accept
+# `context` at all are handled dynamically: the loader drops the key with a
+# warning and the instance keeps the base-class default, ``[]``.
 CONTEXT_NOT_APPLIED = {"BasicLangExtractRecognizer"}
 
 # Classes that cannot be constructed through a `type: predefined` registry
@@ -427,7 +435,7 @@ def test_not_loadable_as_predefined_entry_names_only_real_classes():
 
 @pytest.mark.parametrize("cls", ROUND_TRIP_CLASSES, ids=lambda cls: cls.__name__)
 def test_synthetic_entry_round_trips_to_every_concrete_class(
-    cls, patched_loads, monkeypatch
+    cls, patched_loads, monkeypatch, caplog
 ):
     """A synthetic registry entry round-trips to every concrete class.
 
@@ -436,6 +444,10 @@ def test_synthetic_entry_round_trips_to_every_concrete_class(
     ``context``, and ``score_thresholds`` set in a registry entry actually
     reach the constructed instance, not just that the constructor accepts
     the keys (Story 1/2 already covers acceptance at the signature level).
+
+    For a class that does not accept ``context`` (a multi-entity recognizer),
+    the entry must still load: the loader drops the key, logs a WARNING
+    naming the class, and the instance keeps the base-class default ``[]``.
     """
     for name, value in REQUIRED_ENV.get(cls.__name__, {}).items():
         monkeypatch.setenv(name, value)
@@ -447,9 +459,10 @@ def test_synthetic_entry_round_trips_to_every_concrete_class(
         "recognizers": [entry],
     }
 
-    registry = RecognizerRegistryProvider(
-        registry_configuration=configuration
-    ).create_recognizer_registry()
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        registry = RecognizerRegistryProvider(
+            registry_configuration=configuration
+        ).create_recognizer_registry()
 
     instances = [r for r in registry.recognizers if type(r) is cls]
     assert len(instances) == 1, (
@@ -460,10 +473,31 @@ def test_synthetic_entry_round_trips_to_every_concrete_class(
 
     assert instance.name == f"conf_{cls.__name__}"
     assert instance.supported_language == "en"
-    if cls.__name__ not in CONTEXT_NOT_APPLIED:
-        assert instance.context == ["zeta"], (
-            f"{cls.__name__}: context did not reach the constructed instance"
+    accepts_context = "context" in _reachable_init_param_names(cls)
+    context_warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "WARNING"
+        and cls.__name__ in r.getMessage()
+        and "'context'" in r.getMessage()
+    ]
+    if not accepts_context:
+        assert instance.context == [], (
+            f"{cls.__name__}: does not accept context, so the instance must "
+            f"keep the base-class default"
         )
+        assert context_warnings, (
+            f"{cls.__name__}: context was dropped without a WARNING naming "
+            f"the class and the key"
+        )
+    else:
+        assert not context_warnings, (
+            f"{cls.__name__}: accepts context but the loader warned anyway"
+        )
+        if cls.__name__ not in CONTEXT_NOT_APPLIED:
+            assert instance.context == ["zeta"], (
+                f"{cls.__name__}: context did not reach the constructed instance"
+            )
     assert instance.score_thresholds == {"default": 0.42}
 
 

--- a/presidio-analyzer/tests/test_recognizer_config_conformance.py
+++ b/presidio-analyzer/tests/test_recognizer_config_conformance.py
@@ -1,0 +1,194 @@
+"""Conformance suite for the recognizer registry / YAML configuration layer.
+
+Presidio's YAML configuration layer is a public contract: a key a user can
+set in a registry YAML file either reaches the object it configures, or the
+registry raises a message naming the key. This module is the regression
+suite that turns that promise into something CI checks, rather than
+something a user discovers when they flip ``enabled: true``:
+
+- Story 1/2: every concrete recognizer's constructor must accept the keys
+  ``RecognizerListLoader`` injects (``name``, ``supported_language``,
+  ``context``, and one of ``supported_entity``/``supported_entities``), or
+  enabling it in YAML crashes registry construction with a distant
+  ``TypeError`` instead of a clear failure here.
+- Story 3: every entry in the shipped ``conf/default_recognizers.yaml``
+  loads, and every field it sets reaches the constructed recognizer.
+- Story 4: a synthetic YAML entry for *every* concrete recognizer class
+  round-trips its ``name``, ``context``, and ``score_thresholds`` -- and an
+  unknown key is never silently dropped.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Dict, List, Set, Type
+
+import presidio_analyzer.predefined_recognizers  # noqa: F401 -- see below
+import pytest
+from presidio_analyzer import EntityRecognizer
+from presidio_analyzer.recognizer_registry.recognizers_loader_utils import (
+    RecognizerListLoader,
+)
+
+# The import above registers every concrete predefined-recognizer subclass on
+# ``EntityRecognizer`` before ``get_all_existing_recognizers()`` is called
+# below -- it is otherwise unused in this module.
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_test_double(cls: type) -> bool:
+    """Return True for a recognizer subclass defined inside the test suite.
+
+    Several test modules define a throwaway ``PatternRecognizer`` subclass at
+    module scope for their own tests. Those are not part of the product's
+    recognizer contract and must not be swept into this conformance suite.
+    """
+    module = getattr(cls, "__module__", "") or ""
+    return module == "tests" or module.startswith("tests.")
+
+
+def _concrete_recognizer_classes() -> List[Type[EntityRecognizer]]:
+    return sorted(
+        (
+            cls
+            for cls in RecognizerListLoader.get_all_existing_recognizers()
+            if not inspect.isabstract(cls) and not _is_test_double(cls)
+        ),
+        key=lambda cls: cls.__name__,
+    )
+
+
+# Every concrete (non-abstract, non-test-double) ``EntityRecognizer``
+# subclass presidio ships. Computed once at import time and reused by every
+# story below so they all agree on exactly what "every recognizer" means.
+CONCRETE_RECOGNIZER_CLASSES = _concrete_recognizer_classes()
+
+
+@pytest.fixture
+def patched_loads(monkeypatch):
+    """Patch ``load`` to a no-op on every concrete recognizer class.
+
+    Constructing a recognizer from configuration can otherwise attempt to
+    download a real model (HuggingFace, GLiNER, spaCy...) -- forbidden in a
+    test. This suite only proves that configuration keys reach the
+    constructed object, never that a model actually loads, so no test here
+    may exercise a real ``load()``.
+    """
+    for cls in CONCRETE_RECOGNIZER_CLASSES:
+        monkeypatch.setattr(cls, "load", lambda self: None, raising=False)
+
+
+def _reachable_init_param_names(cls: Type[EntityRecognizer]) -> Set[str]:
+    """Union of ``__init__`` parameter names reachable from the loader.
+
+    Walks ``cls.__mro__`` starting at ``cls`` itself. Each class along the
+    chain that defines its own ``__init__`` contributes its parameter names
+    (excluding ``self`` and the ``*args``/``**kwargs`` slots themselves) to
+    the union. Traversal stops right after the first ``__init__`` that does
+    NOT accept ``**kwargs``: once a constructor stops forwarding arbitrary
+    keyword arguments to its superclass, a key the registry loader passes
+    for a parameter declared only further up the MRO can never actually
+    reach that superclass, so it is not "reachable" from the loader's point
+    of view.
+    """
+    names: Set[str] = set()
+    for klass in cls.__mro__:
+        init = klass.__dict__.get("__init__")
+        if init is None:
+            continue
+        try:
+            parameters = inspect.signature(init).parameters
+        except (TypeError, ValueError):
+            break
+        names.update(
+            name
+            for name, param in parameters.items()
+            if name != "self"
+            and param.kind
+            not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+        )
+        has_var_kw = any(
+            param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
+        )
+        if not has_var_kw:
+            break
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Story 1 & 2: base-class contract conformance
+# ---------------------------------------------------------------------------
+
+# Keys ``RecognizerListLoader`` injects into every predefined recognizer it
+# builds from a registry entry (see ``RecognizerListLoader.get`` /
+# ``_prepare_recognizer_kwargs``).
+REGISTRY_INJECTED_KEYS = ("name", "supported_language", "context")
+ENTITY_KEYS = ("supported_entity", "supported_entities")
+
+# These LangExtract-based recognizers take their supported entities from the
+# YAML file at ``config_path`` (see ``LangExtractRecognizer.__init__`` /
+# ``get_supported_entities``), never from a ``supported_entity(ies)``
+# constructor kwarg, so the entity-key requirement below does not apply to
+# them. ``LangExtractRecognizer`` itself is abstract and never reaches the
+# parametrized test below, but is listed for completeness/documentation.
+ENTITIES_FROM_OWN_CONFIG = {
+    "LangExtractRecognizer",
+    "BasicLangExtractRecognizer",
+    "AzureOpenAILangExtractRecognizer",
+}
+
+# Regression lock: classes whose constructor cannot yet accept every key the
+# registry loader injects, mapped to exactly which keys are missing.
+# Verified against the real signatures via ``_reachable_init_param_names``
+# below -- the test asserts the *actual* gap set equals this dict exactly,
+# so fixing a class without shrinking this dict fails the test, and so does
+# a newly introduced regression.
+KNOWN_CONTRACT_GAPS: Dict[str, Set[str]] = {
+    "AzureHealthDeidRecognizer": {"context"},
+    "AzureOpenAILangExtractRecognizer": {"context"},
+    "MedicalNERRecognizer": {"context"},
+}
+
+
+def _missing_registry_keys(cls: Type[EntityRecognizer]) -> Set[str]:
+    reachable = _reachable_init_param_names(cls)
+    missing = {key for key in REGISTRY_INJECTED_KEYS if key not in reachable}
+    if cls.__name__ not in ENTITIES_FROM_OWN_CONFIG and not any(
+        key in reachable for key in ENTITY_KEYS
+    ):
+        missing.add("supported_entity/supported_entities")
+    return missing
+
+
+@pytest.mark.parametrize(
+    "cls", CONCRETE_RECOGNIZER_CLASSES, ids=lambda cls: cls.__name__
+)
+def test_recognizer_accepts_registry_injected_keys(cls):
+    """Assert the constructor accepts every key the registry loader injects.
+
+    A constructor that rejects one of these crashes registry construction
+    the moment a user enables that recognizer in YAML --
+    ``TypeError: __init__() got an unexpected keyword argument ...`` -- for
+    the *whole* registry, not just this recognizer. Catch that here instead.
+    """
+    missing = _missing_registry_keys(cls)
+    expected = KNOWN_CONTRACT_GAPS.get(cls.__name__, set())
+    assert missing == expected, (
+        f"{cls.__name__} is missing registry-injected keys {sorted(missing)}; "
+        f"KNOWN_CONTRACT_GAPS expects exactly {sorted(expected)}. Either make "
+        f"the constructor accept the missing key(s), or update "
+        f"KNOWN_CONTRACT_GAPS to match reality."
+    )
+
+
+def test_known_contract_gaps_names_only_real_classes():
+    """Guard ``KNOWN_CONTRACT_GAPS`` against stale entries.
+
+    A class renamed or removed should fail loudly here, not quietly narrow
+    coverage.
+    """
+    names = {cls.__name__ for cls in CONCRETE_RECOGNIZER_CLASSES}
+    assert set(KNOWN_CONTRACT_GAPS) <= names

--- a/presidio-analyzer/tests/test_recognizer_config_conformance.py
+++ b/presidio-analyzer/tests/test_recognizer_config_conformance.py
@@ -21,13 +21,22 @@ something a user discovers when they flip ``enabled: true``:
 from __future__ import annotations
 
 import inspect
-from typing import Dict, List, Set, Type
+from typing import Any, Dict, List, Set, Tuple, Type
 
 import presidio_analyzer.predefined_recognizers  # noqa: F401 -- see below
 import pytest
 from presidio_analyzer import EntityRecognizer
+from presidio_analyzer.recognizer_registry import RecognizerRegistryProvider
 from presidio_analyzer.recognizer_registry.recognizers_loader_utils import (
     RecognizerListLoader,
+)
+from presidio_analyzer.score_thresholds import normalize_score_thresholds
+
+from tests.test_recognizers_loader_utils import (
+    DEFAULT_CONF_DATA,
+    GLOBAL_REGEX_FLAGS,
+    NOT_LOADABLE_FROM_SHIPPED_ENTRY,
+    PACKAGE_ROOT,
 )
 
 # The import above registers every concrete predefined-recognizer subclass on
@@ -194,3 +203,120 @@ def test_known_contract_gaps_names_only_real_classes():
     """
     names = {cls.__name__ for cls in CONCRETE_RECOGNIZER_CLASSES}
     assert set(KNOWN_CONTRACT_GAPS) <= names
+
+
+# ---------------------------------------------------------------------------
+# Story 3: shipped configuration field-reach test
+# ---------------------------------------------------------------------------
+
+
+def _shipped_entries() -> List[Dict[str, Any]]:
+    """Normalize every entry of the shipped ``default_recognizers.yaml``."""
+    entries = []
+    for entry in DEFAULT_CONF_DATA["recognizers"]:
+        entries.append({"name": entry} if isinstance(entry, str) else dict(entry))
+    return entries
+
+
+def _entry_id(entry: Dict[str, Any]) -> str:
+    return entry.get("class_name") or entry["name"]
+
+
+def _entry_language_configs(entry: Dict[str, Any]) -> List[Tuple[str, Any]]:
+    """(language, context) pairs, in the shape the loader builds per language.
+
+    Mirrors ``RecognizerListLoader._get_recognizer_languages``: a missing
+    ``supported_languages`` falls back to the file's top-level languages, a
+    bare list of language codes carries no per-language context, and a list
+    of ``{language, context}`` dicts carries whatever context each one sets
+    (``None`` if it sets none).
+    """
+    languages = entry.get("supported_languages")
+    if not languages:
+        return [
+            (language, None)
+            for language in DEFAULT_CONF_DATA.get("supported_languages") or ["en"]
+        ]
+    if isinstance(languages[0], str):
+        return [(language, None) for language in languages]
+    return [(item["language"], item.get("context")) for item in languages]
+
+
+SHIPPED_ENTRIES = _shipped_entries()
+# Entries that cannot construct from their shipped configuration alone (see
+# the set's own docstring/comment in tests/test_recognizers_loader_utils.py
+# for why) -- reused here rather than duplicated, so exactly one such set
+# exists in the test suite.
+LOADABLE_SHIPPED_ENTRIES = [
+    entry
+    for entry in SHIPPED_ENTRIES
+    if _entry_id(entry) not in NOT_LOADABLE_FROM_SHIPPED_ENTRY
+]
+
+
+@pytest.mark.parametrize("entry", LOADABLE_SHIPPED_ENTRIES, ids=_entry_id)
+def test_shipped_entry_fields_reach_constructed_recognizer(
+    entry, patched_loads, monkeypatch
+):
+    """Every shipped entry loads, and every field it sets reaches the object.
+
+    Builds a single-recognizer registry config from one shipped entry (with
+    ``enabled`` forced true) and loads it through
+    ``RecognizerRegistryProvider`` -- the same path a real user's YAML goes
+    through -- then checks that the entry's language(s), per-language
+    context, name, and (when set) ``supported_entities`` /
+    ``score_thresholds`` all reached the constructed instance(s).
+
+    Runs from ``PACKAGE_ROOT`` so a ``config_path`` the recognizer resolves
+    against the working directory behaves as it does in CI (mirroring
+    ``test_yaml_entry_loads_when_enabled`` in
+    ``test_recognizers_loader_utils.py``).
+    """
+    entry_id = _entry_id(entry)
+    language_configs = _entry_language_configs(entry)
+    languages = [language for language, _ in language_configs]
+    conf_entry = dict(entry, enabled=True)
+    configuration = {
+        "global_regex_flags": GLOBAL_REGEX_FLAGS,
+        "supported_languages": languages,
+        "recognizers": [conf_entry],
+    }
+    monkeypatch.chdir(PACKAGE_ROOT)
+
+    registry = RecognizerRegistryProvider(
+        registry_configuration=configuration
+    ).create_recognizer_registry()
+
+    instances = [r for r in registry.recognizers if type(r).__name__ == entry_id]
+    assert len(instances) == len(languages), (
+        f"{entry_id}: expected one instance per language {languages}, got "
+        f"{[r.supported_language for r in instances]}"
+    )
+
+    by_language = {instance.supported_language: instance for instance in instances}
+    assert set(by_language) == set(languages), (
+        f"{entry_id}: constructed languages {sorted(by_language)} do not match "
+        f"the entry's languages {sorted(languages)}"
+    )
+
+    for language, context in language_configs:
+        if context is not None:
+            assert by_language[language].context == context, (
+                f"{entry_id}/{language}: context {context!r} from the shipped "
+                f"entry did not reach the constructed recognizer"
+            )
+
+    for instance in instances:
+        assert instance.name == entry["name"], (
+            f"{entry_id}: entry name {entry['name']!r} did not reach the "
+            f"constructed recognizer"
+        )
+
+    if entry.get("supported_entities"):
+        for instance in instances:
+            assert instance.supported_entities == entry["supported_entities"]
+
+    if entry.get("score_thresholds") is not None:
+        expected_thresholds = normalize_score_thresholds(entry["score_thresholds"])
+        for instance in instances:
+            assert instance.score_thresholds == expected_thresholds

--- a/presidio-analyzer/tests/test_recognizer_config_conformance.py
+++ b/presidio-analyzer/tests/test_recognizer_config_conformance.py
@@ -146,11 +146,13 @@ ENTITIES_FROM_OWN_CONFIG = {
 # below -- the test asserts the *actual* gap set equals this dict exactly,
 # so fixing a class without shrinking this dict fails the test, and so does
 # a newly introduced regression.
-KNOWN_CONTRACT_GAPS: Dict[str, Set[str]] = {
-    "AzureHealthDeidRecognizer": {"context"},
-    "AzureOpenAILangExtractRecognizer": {"context"},
-    "MedicalNERRecognizer": {"context"},
-}
+#
+# Empty: AzureHealthDeidRecognizer, AzureOpenAILangExtractRecognizer and
+# MedicalNERRecognizer were the three gaps at the time this suite was added
+# (all missing `context`) and were closed in the same turn -- see their
+# constructors and the `context=[...]` tests in their respective test
+# modules.
+KNOWN_CONTRACT_GAPS: Dict[str, Set[str]] = {}
 
 
 def _missing_registry_keys(cls: Type[EntityRecognizer]) -> Set[str]:

--- a/presidio-analyzer/tests/test_recognizer_config_conformance.py
+++ b/presidio-analyzer/tests/test_recognizer_config_conformance.py
@@ -454,7 +454,7 @@ def test_synthetic_entry_round_trips_to_every_concrete_class(
 
     entry = _synthetic_entry(cls)
     configuration = {
-        "global_regex_flags": 26,
+        "global_regex_flags": GLOBAL_REGEX_FLAGS,
         "supported_languages": ["en"],
         "recognizers": [entry],
     }
@@ -522,7 +522,7 @@ def test_unknown_key_is_not_silent(caplog):
     removed rather than silently masking the fix forever.
     """
     configuration = {
-        "global_regex_flags": 26,
+        "global_regex_flags": GLOBAL_REGEX_FLAGS,
         "supported_languages": ["en"],
         "recognizers": [
             {

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -311,6 +311,51 @@ def test_dropped_entity_key_warns_for_class_defining_its_own_entities(caplog):
     assert kwargs["supported_entities"] == ["X"]
 
 
+def test_context_dropped_with_warning_for_class_not_accepting_it(caplog):
+    """A registry entry that sets context for a class whose constructor does
+    not accept it (a multi-entity recognizer such as MedicalNERRecognizer)
+    must still load: the key is dropped and a WARNING names the class and
+    the key, instead of the constructor raising TypeError and taking the
+    whole registry down.
+    """
+    from presidio_analyzer.predefined_recognizers import MedicalNERRecognizer
+
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        kwargs = RecognizerListLoader._prepare_recognizer_kwargs(
+            recognizer_conf={},
+            language_conf={"supported_language": "en", "context": ["patient"]},
+            recognizer_cls=MedicalNERRecognizer,
+        )
+
+    assert "context" not in kwargs
+    assert kwargs["supported_language"] == "en"
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert any(
+        "MedicalNERRecognizer" in m and "'context'" in m for m in warning_messages
+    ), f"expected a dropped-context WARNING, got {warning_messages!r}"
+
+
+def test_context_kept_without_warning_for_class_accepting_it(caplog):
+    """A class that accepts context (single-entity pattern recognizers, and
+    classes forwarding **kwargs to a parent that accepts it) receives it
+    unchanged and nothing is logged.
+    """
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        kwargs = RecognizerListLoader._prepare_recognizer_kwargs(
+            recognizer_conf={},
+            language_conf={"supported_language": "en", "context": ["visa"]},
+            recognizer_cls=CreditCardRecognizer,
+        )
+
+    assert kwargs["context"] == ["visa"]
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert not warning_messages, f"expected no WARNING, got {warning_messages!r}"
+
+
 def test_no_warning_when_class_accepts_the_entity_key(caplog):
     """A class that does accept supported_entity/supported_entities (e.g.
     CreditCardRecognizer, which accepts the singular form) logs nothing --
@@ -373,6 +418,7 @@ def test_country_filter_includes_tagged_custom_recognizer():
     """A custom recognizer that opts in via class-level ``COUNTRY_CODE`` is
     included when the filter is loaded with the matching country.
     """
+
     class _BrCpfRecognizer(PatternRecognizer):
         COUNTRY_CODE = "br"
 
@@ -412,6 +458,7 @@ def test_country_filter_warns_on_unknown_country(caplog):
     list, a WARNING is logged so silent zero-result filters are easier to
     debug.
     """
+
     class _XUsRecognizer(PatternRecognizer):
         COUNTRY_CODE = "us"
 
@@ -546,6 +593,7 @@ def test_filter_by_countries_normalizes_case_and_whitespace():
 
     ``" US "`` matches a ``COUNTRY_CODE = "us"`` recognizer.
     """
+
     class TaggedRecognizer(PatternRecognizer):
         COUNTRY_CODE = "us"
 

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -373,6 +373,27 @@ def test_no_warning_when_class_accepts_the_entity_key(caplog):
     assert not warning_messages, f"expected no WARNING, got {warning_messages!r}"
 
 
+def test_no_warning_when_kwargs_forwarding_reaches_a_declaring_parent(caplog):
+    """A class whose own __init__ declares neither key but forwards **kwargs
+    to a base class that does declare supported_entities (e.g.
+    TransformersRecognizer/StanzaRecognizer forwarding to SpacyRecognizer)
+    genuinely applies the value further up the chain -- it must not be
+    reported as ignored.
+    """
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        kwargs = prepare(
+            recognizer_conf={"supported_entities": ["ENT"]},
+            recognizer_cls=ChildForwardsKwargs,
+        )
+
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert not warning_messages, f"expected no WARNING, got {warning_messages!r}"
+    # The value really does reach StrictParent's declared parameter.
+    assert kwargs["supported_entities"] == ["ENT"]
+
+
 def test_inheritance_forwarding_does_not_crash():
     """Test that inheritance forwarding to strict parent does not crash."""
     # Verify both:

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -356,6 +356,47 @@ def test_context_kept_without_warning_for_class_accepting_it(caplog):
     assert not warning_messages, f"expected no WARNING, got {warning_messages!r}"
 
 
+def test_no_warning_when_entity_key_is_reachable_through_kwargs_forwarding(caplog):
+    """A subclass whose own signature names neither entity key but forwards
+    **kwargs to a parent that accepts one (StanzaRecognizer -> SpacyRecognizer)
+    does apply the key, so no "ignoring" warning may be logged and the key must
+    stay in kwargs.
+    """
+    from presidio_analyzer.predefined_recognizers import StanzaRecognizer
+
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        kwargs = RecognizerListLoader._prepare_recognizer_kwargs(
+            recognizer_conf={"supported_entities": ["PERSON"]},
+            language_conf={"supported_language": "en", "context": ["name"]},
+            recognizer_cls=StanzaRecognizer,
+        )
+
+    assert kwargs["supported_entities"] == ["PERSON"]
+    assert kwargs["context"] == ["name"]
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert not warning_messages, f"expected no WARNING, got {warning_messages!r}"
+
+
+def test_reachable_init_param_names_stops_at_first_init_without_kwargs():
+    """StanzaRecognizer forwards **kwargs, so SpacyRecognizer's parameters are
+    reachable; MedicalNERRecognizer does not, so HuggingFaceNerRecognizer's
+    ``context`` is not, even though the parent accepts it.
+    """
+    from presidio_analyzer.predefined_recognizers import (
+        MedicalNERRecognizer,
+        StanzaRecognizer,
+    )
+
+    stanza = RecognizerListLoader._reachable_init_param_names(StanzaRecognizer)
+    assert {"supported_entities", "context", "supported_language"} <= stanza
+
+    medical = RecognizerListLoader._reachable_init_param_names(MedicalNERRecognizer)
+    assert "context" not in medical
+    assert "supported_entities" in medical
+
+
 def test_no_warning_when_class_accepts_the_entity_key(caplog):
     """A class that does accept supported_entity/supported_entities (e.g.
     CreditCardRecognizer, which accepts the singular form) logs nothing --

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -15,6 +15,9 @@ from presidio_analyzer.predefined_recognizers import (
     CreditCardRecognizer,
     UsSsnRecognizer,
 )
+from presidio_analyzer.predefined_recognizers.third_party.basic_langextract_recognizer import (  # noqa: E501
+    BasicLangExtractRecognizer,
+)
 from presidio_analyzer.recognizer_registry import RecognizerRegistryProvider
 from presidio_analyzer.recognizer_registry.recognizers_loader_utils import (
     RecognizerConfigurationLoader,
@@ -281,6 +284,48 @@ def test_uninspectable_signature_drops_entity_keys():
     )
     assert "supported_entities" not in kwargs
     assert "supported_entity" not in kwargs
+
+
+def test_dropped_entity_key_warns_for_class_defining_its_own_entities(caplog):
+    """A class that accepts neither supported_entity nor supported_entities
+    (it defines its entities from its own configuration, e.g. a LangExtract
+    config file) still loads when the entry sets supported_entities -- but a
+    WARNING naming the class and the dropped key is logged instead of
+    silently discarding the value.
+    """
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        kwargs = prepare(
+            recognizer_conf={"supported_entities": ["X"]},
+            recognizer_cls=BasicLangExtractRecognizer,
+        )
+
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert any(
+        "BasicLangExtractRecognizer" in m and "supported_entities" in m
+        for m in warning_messages
+    ), f"expected a dropped-entity-key WARNING, got {warning_messages!r}"
+    # Unchanged behavior: supported_entities still reaches kwargs (the class
+    # accepts **kwargs and simply ignores it, using its config-file entities).
+    assert kwargs["supported_entities"] == ["X"]
+
+
+def test_no_warning_when_class_accepts_the_entity_key(caplog):
+    """A class that does accept supported_entity/supported_entities (e.g.
+    CreditCardRecognizer, which accepts the singular form) logs nothing --
+    the warning is specific to classes that define their entities themselves.
+    """
+    with caplog.at_level("WARNING", logger="presidio-analyzer"):
+        prepare(
+            recognizer_conf={"supported_entities": ["CREDIT_CARD"]},
+            recognizer_cls=CreditCardRecognizer,
+        )
+
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert not warning_messages, f"expected no WARNING, got {warning_messages!r}"
 
 
 def test_inheritance_forwarding_does_not_crash():

--- a/presidio-analyzer/tests/test_recognizers_loader_utils.py
+++ b/presidio-analyzer/tests/test_recognizers_loader_utils.py
@@ -287,11 +287,11 @@ def test_uninspectable_signature_drops_entity_keys():
 
 
 def test_dropped_entity_key_warns_for_class_defining_its_own_entities(caplog):
-    """A class that accepts neither supported_entity nor supported_entities
-    (it defines its entities from its own configuration, e.g. a LangExtract
-    config file) still loads when the entry sets supported_entities -- but a
-    WARNING naming the class and the dropped key is logged instead of
-    silently discarding the value.
+    """A class that has neither supported_entity nor supported_entities
+    reachable anywhere in its constructor chain (it defines its entities from
+    its own configuration, e.g. a LangExtract config file) still loads when
+    the entry sets supported_entities -- but a WARNING naming the class and
+    the ineffective key is logged instead of staying silent about it.
     """
     with caplog.at_level("WARNING", logger="presidio-analyzer"):
         kwargs = prepare(
@@ -305,7 +305,7 @@ def test_dropped_entity_key_warns_for_class_defining_its_own_entities(caplog):
     assert any(
         "BasicLangExtractRecognizer" in m and "supported_entities" in m
         for m in warning_messages
-    ), f"expected a dropped-entity-key WARNING, got {warning_messages!r}"
+    ), f"expected an ineffective-entity-key WARNING, got {warning_messages!r}"
     # Unchanged behavior: supported_entities still reaches kwargs (the class
     # accepts **kwargs and simply ignores it, using its config-file entities).
     assert kwargs["supported_entities"] == ["X"]


### PR DESCRIPTION
## Change Description

Adds `tests/test_recognizer_config_conformance.py`, the conformance suite for the recognizer registry / YAML configuration layer (ADR module M0): a parametrized check that every concrete recognizer's constructor accepts the keys `RecognizerListLoader` injects from a registry YAML entry (`name`, `supported_language`, `context`, and one of `supported_entity`/`supported_entities`), a field-reach test over every entry of the shipped `conf/default_recognizers.yaml`, and a per-class round-trip test that builds a synthetic registry entry for every concrete recognizer class and asserts `name`/`context`/`score_thresholds` actually reach the constructed instance. It also fixes, in the loader, the registry-build crash the first of these tests found (a `context` entry on a recognizer whose constructor does not accept it), and adds `logger.warning` calls for two previously-silent cases the tests surfaced.

### Behavior changes

None to detection results or scores. Two new `logger.warning` lines, and one `TypeError` that becomes a warning:

- `RecognizerListLoader._prepare_recognizer_kwargs` now drops `context` when the recognizer class does not accept it, and logs a WARNING naming the class and the key. Before this PR the same entry raised `TypeError: __init__() got an unexpected keyword argument 'context'` and the whole registry failed to build. Nothing changes for classes that accept `context`.
- The loader already silently dropped `supported_entity`/`supported_entities` for a class whose constructor accepts neither (e.g. `BasicLangExtractRecognizer`, which derives its entities from its own config file). That case now logs a WARNING naming the class and the dropped key instead of staying silent.

No entity or PII values are logged, only class names and key names. No constructor signature changes.

### Bare-string entries now build a recognizer

`recognizers: [CreditCardRecognizer]` is the shorthand the configuration schema accepts for a predefined recognizer with no further settings. `_split_recognizers` required a mapping for the predefined list and excluded strings from the custom list, so the entry matched neither and **no recognizer was built**: the registry came back empty with no error, and a mixed list silently lost only its string entries. A bare string is now expanded to `{name: <str>, type: predefined}` at that single chokepoint.

Behavior changes:

- A bare-string entry now constructs the named recognizer instead of being silently discarded. A registry using this form gains the recognizers it already asked for.
- A bare-string entry naming an unknown class now raises `PredefinedRecognizerNotFoundError`, matching what a `name:` in a mapping entry already did, instead of yielding an empty registry with no diagnostic.
- Mapping entries are unaffected, and the shipped `default_recognizers.yaml` has no bare-string entries, so the default registry is unchanged.

Five tests cover the path (split normalization, construction, one instance per registry language, mixed with mapping entries, unknown name raising); all five were verified to fail without the fix. Four more pin that YAML-defined `type: custom` recognizers are untouched by the predefined-path rules this PR adds: their fields survive and none of the new warnings fire, an entry without a `type` key is still custom, and a multi-language custom entry keeps per-language context.

### Why `context` is handled in the loader, not the constructors

`EntityRecognizer.context` is one flat list of context words applied to every result the recognizer emits. That is meaningful for a recognizer that detects a single entity type (the pattern recognizers), and meaningless for one that detects several: `MedicalNERRecognizer`, `AzureHealthDeidRecognizer` and the LangExtract recognizers would boost a DATE as much as a NAME. Those classes deliberately do not accept `context`, and this PR does not add it to them.

What was broken is that a registry entry setting `context` for such a class crashed the whole registry build. The fix is one rule in the loader: a `context` key the class does not accept is dropped with a warning naming the class. The conformance contract is therefore `name`, `supported_language` and an entity key; `context` is not part of it.

### What's in each commit / story

1. **Story 1** — `test_recognizer_accepts_registry_injected_keys`, parametrized over every concrete `EntityRecognizer` subclass, walking each constructor's `__init__` MRO to compute which registry-injected keys are reachable. `KNOWN_CONTRACT_GAPS` regression-locks the three gaps found (all `context`); `ENTITIES_FROM_OWN_CONFIG` documents the LangExtract family's legitimate exemption from the entity-key requirement.
2. **Story 2** — the loader-side `context` rule described above plus its two tests (`test_context_dropped_with_warning_for_class_not_accepting_it`, `test_context_kept_without_warning_for_class_accepting_it`), and the dropped-entity-key warning plus its two tests (`test_dropped_entity_key_warns_for_class_defining_its_own_entities`, `test_no_warning_when_class_accepts_the_entity_key`), all in `test_recognizers_loader_utils.py`. `KNOWN_CONTRACT_GAPS` is empty: every concrete recognizer already meets the `name` / `supported_language` / entity-key contract.
3. **Story 3** — `test_shipped_entry_fields_reach_constructed_recognizer`, parametrized over every entry of `conf/default_recognizers.yaml`: loads each through `RecognizerRegistryProvider` and asserts language count, `supported_language`, per-language `context`, `name`, and (when set) `supported_entities`/`score_thresholds` all reach the constructed instance(s). Reuses `NOT_LOADABLE_FROM_SHIPPED_ENTRY` from `tests/test_recognizers_loader_utils.py` (imported, not duplicated).
4. **Story 4** — `test_synthetic_entry_round_trips_to_every_concrete_class`, parametrized over every concrete recognizer class with a synthetic `conf_<Class>` entry; `REQUIRED_KWARGS`/`REQUIRED_ENV` supply what a handful of classes need to construct (an Azure endpoint/credentials, `HuggingFaceNerRecognizer`'s `model_name`); `NOT_LOADABLE_AS_PREDEFINED_ENTRY` documents three classes that structurally cannot be built through a `type: predefined` entry at all (`LocalRecognizer`, `PatternRecognizer`, `ZaPhoneNumberRecognizer` — all subclassing-only base classes); for a class that does not accept `context` the test asserts the entry still loads, the instance keeps the base default `[]`, and the loader WARNING names the class; `CONTEXT_NOT_APPLIED` documents `BasicLangExtractRecognizer`'s pre-existing (unchanged) "accepts but doesn't apply `context`" behavior. `test_unknown_key_is_not_silent` documents today's silent-drop gap for an unrecognized YAML key and is marked `xfail(strict=True, reason="flipped in turn 06 (derived schema)")` — it is expected to fail today; that is the point, and it will force the marker's removal the moment turn 06 closes the gap.

### Notes / known limitations

- Commit `a2106de` added `context` to three constructors; commit `45c8a3b` reverts that and moves the fix into the loader, per review. The net diff contains no constructor changes.
- Commit `ecd8a19` addresses the second Copilot review round:
  - **Optional extras no longer hard-fail.** Six classes import `transformers`, the Azure SDKs or `langextract` in their constructor, so on a core/dev install without `--all-extras` the suite raised `ImportError` instead of skipping. `OPTIONAL_DEPENDENCY_MODULES` now skips those parametrized cases when the module is absent. The skip probes for the module rather than catching the exception, so an unexpected `ImportError` from any class still fails. Verified with those modules hidden: the 7 previously failing cases skip and 302 pass.
  - **A `context` carve-out for `**kwargs` leaves was added here and then reverted as unsound.** The intent was to keep `context` for a leaf constructor accepting `**kwargs`, on the theory that such a class could read the key itself. That is wrong: `_reachable_init_param_names` already follows `**kwargs` up the MRO, so "unreachable" means the forwarding chain breaks at a class that does not declare `context`, and leaving the key in raises `TypeError` at that parent -- the exact crash this rule exists to prevent. Reproduced directly against the `ChildForwardsKwargs` -> `StrictParent` test double. The drop is unconditional when `context` is unreachable, and the regression test now constructs the class rather than only inspecting the prepared kwargs.
  - **`_entry_language_configs` now mirrors the loader** on the no-`supported_languages` path, carrying the entry-level `context` into each fallback language instead of `None`. Eleven shipped entries take that path, so the test would have stopped checking context if one ever set the key. An empty language list is now rejected explicitly rather than treated as omitted.
  - Corrected the comment claiming the branch leaves the entity key in `kwargs`: `supported_entity` is always filtered out later when not declared.

### Known gaps, deliberately left open

- **Entry-level `context` is silently discarded when `supported_languages` is a bare list of language codes.** `BaseRecognizerConfig` accepts that shape, but only the per-language `{language, context}` form reaches the recognizer. `test_entry_context_is_dropped_for_bare_language_list` pins today's behavior rather than changing the loader, which would alter detection for anyone whose YAML relies on the current result. No shipped entry combines the two keys.
- **The synthetic round-trip entry does not set an entity key**, so the loader's `supported_entity`/`supported_entities` path is covered at the signature level but not end to end. Closing it needs a valid entity name per class, which is a larger change than this turn should carry.

- Commit `6b5233b2` addresses the last Copilot review comment: the shipped-entry test gated its `supported_entities` assertion on truthiness, so an entry explicitly setting `supported_entities: []` was treated as "not set" and skipped. It now gates on key presence. Verified separately that `supported_entities: []` does **not** round-trip today (the recognizer falls back to its own default entity list), so the previous truthiness guard would have hidden exactly the kind of silent-drop this suite exists to catch. No shipped entry sets the key, so nothing changes for the current configuration. The same commit renames `dropped_keys` to `ineffective_keys` and renames `test_dropped_entity_key_warns_*` to `test_ineffective_entity_key_warns_*`, because that branch warns without removing the key.
- Commits `7cd44e3` and `31fa9b0` address the Copilot review comment: both loader warnings and the `context` drop now key off `RecognizerListLoader._reachable_init_param_names` (constructor parameters reachable through `**kwargs` forwarding along the MRO), so `StanzaRecognizer` and `TransformersRecognizer`, which forward to `SpacyRecognizer`, are not reported as ignoring keys they apply.

- `uv run ruff format --check .` flags 26 pre-existing files unrelated to this PR (confirmed identical on `origin/main` before this branch's changes); the actual CI lint gate (`.github/workflows/ci.yml`) only runs `ruff check`, which is fully green. No file touched by this PR needs reformatting.
- Full local run with `uv sync --locked --all-extras --group dev`: `3772 passed, 13 skipped, 1 xfailed`. `ruff check` and `ruff format --check` are clean on all three touched files. Without the optional extras installed, 7 of the new conformance cases fail with `ImportError` rather than skipping (transformers, langextract, azure SDKs); CI installs all extras, so this only affects contributors running a partial environment.

## Issue reference

Part of the ADR at https://github.com/data-privacy-stack/presidio-product-core/issues/139.

Turn 02 of 6. Turn 01 is PR #2210.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required (none needed: no new entities, no schema changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cYn8gUDL2txRa5V7r4vLZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014cYn8gUDL2txRa5V7r4vLZ)_
